### PR TITLE
Fix build on Windows and bug in base quaternion initialisation

### DIFF
--- a/human-forces-provider/CMakeLists.txt
+++ b/human-forces-provider/CMakeLists.txt
@@ -37,6 +37,10 @@ set(HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/HumanForcesProvider.h
 ## Declare a C++ executable
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
 
+if (MSVC)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE -D_USE_MATH_DEFINES)
+endif ()
+
 ## Include directories
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 

--- a/human-forces-provider/src/RobotFrameTransformer.cpp
+++ b/human-forces-provider/src/RobotFrameTransformer.cpp
@@ -5,6 +5,7 @@
  * @copyright iCub Facility - Istituto Italiano di Tecnologia
  */
 
+#include <cmath>
 
 #include "RobotFrameTransformer.h"
 
@@ -15,7 +16,6 @@
 #include <iDynTree/yarp/YARPConversions.h>
 #include <iDynTree/Core/EigenHelpers.h>
 
-#include <cmath>
 
 namespace human
 {

--- a/human-state-provider/src/HumanStateProvider.cpp
+++ b/human-state-provider/src/HumanStateProvider.cpp
@@ -406,7 +406,7 @@ namespace human {
         tempOutput.baseOriginWRTGlobal.x = 0;
         tempOutput.baseOriginWRTGlobal.y = 0;
         tempOutput.baseOriginWRTGlobal.z = 0;
-        tempOutput.baseOrientationWRTGlobal.w = 0;
+        tempOutput.baseOrientationWRTGlobal.w = 1;
         tempOutput.baseOrientationWRTGlobal.imaginary.x = 0;
         tempOutput.baseOrientationWRTGlobal.imaginary.y = 0;
         tempOutput.baseOrientationWRTGlobal.imaginary.z = 0;

--- a/human-viz-bridge/CMakeLists.txt
+++ b/human-viz-bridge/CMakeLists.txt
@@ -16,6 +16,10 @@ target_include_directories(human-viz-bridge-thrift SYSTEM PUBLIC ${YARP_INCLUDE_
 # TF bridge
 add_executable(human-tf-bridge src/HumanTFBridge.cpp)
 
+if (MSVC)
+  target_compile_definitions(human-tf-bridge PRIVATE -D_USE_MATH_DEFINES)
+endif ()
+
 add_warnings_configuration_to_target(TARGETS human-tf-bridge PRIVATE)
 
 target_link_libraries(human-tf-bridge YARP::YARP_OS 
@@ -33,6 +37,10 @@ list(APPEND conf config/human-tf-bridge.ini)
 # Joints bridge                                                
                                                 
 add_executable(human-jointstate-bridge src/HumanJointStateBridge.cpp)
+
+if (MSVC)
+  target_compile_definitions(human-jointstate-bridge PRIVATE -D_USE_MATH_DEFINES)
+endif ()
 
 add_warnings_configuration_to_target(TARGETS human-jointstate-bridge PRIVATE)
 
@@ -53,6 +61,10 @@ list(APPEND conf config/human-jointstate-bridge.ini)
 
 add_executable(human-effort-bridge src/HumanEffortBridge.cpp)
 
+if (MSVC)
+  target_compile_definitions(human-effort-bridge PRIVATE -D_USE_MATH_DEFINES)
+endif ()
+
 target_link_libraries(human-effort-bridge YARP::YARP_OS 
                                           YARP::YARP_dev
                                           iDynTree::idyntree-model
@@ -70,6 +82,10 @@ list(APPEND conf config/human-effort-bridge.ini)
 # Robot Base pose provider
 
 add_executable(robot-basepose-publisher src/RobotBasePosePublisher.cpp)
+
+if (MSVC)
+  target_compile_definitions(robot-basepose-publisher PRIVATE -D_USE_MATH_DEFINES)
+endif ()
 
 target_link_libraries(robot-basepose-publisher  YARP::YARP_OS 
                                                YARP::YARP_dev

--- a/human-viz-bridge/src/RobotBasePosePublisher.cpp
+++ b/human-viz-bridge/src/RobotBasePosePublisher.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include "geometry_msgs_Quaternion.h"
 #include "geometry_msgs_TransformStamped.h"
 #include "geometry_msgs_Vector3.h"
@@ -29,7 +31,6 @@
 #include <yarp/dev/IEncoders.h>
 
 #include <algorithm>
-#include <cmath>
 #include <iostream>
 #include <limits.h>
 #include <string>

--- a/inverse-kinematics/CMakeLists.txt
+++ b/inverse-kinematics/CMakeLists.txt
@@ -13,6 +13,10 @@ set(PRIVATE_HEADERS include/private/InverseKinematicsIPOPT.h
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS} ${PRIVATE_SOURCES} ${PRIVATE_HEADERS})
 
+if (MSVC)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE -D_USE_MATH_DEFINES)
+endif ()
+
 target_compile_definitions(${PROJECT_NAME} PRIVATE ${IPOPT_DEFINITIONS})
 
 if (HUMAN_DYNAMICS_ESTIMATION_DEBUG_MALLOC)

--- a/inverse-kinematics/src/InverseKinematicsIPOPT.cpp
+++ b/inverse-kinematics/src/InverseKinematicsIPOPT.cpp
@@ -1,8 +1,8 @@
+#include <cmath>
 #include "InverseKinematicsIPOPT.h"
 #include <iDynTree/Core/EigenHelpers.h>
 #include <string>
 #include <vector>
-#include <cmath>
 #include <cassert>
 
 using namespace std;

--- a/inverse-kinematics/src/InverseKinematicsV2IPOPT.cpp
+++ b/inverse-kinematics/src/InverseKinematicsV2IPOPT.cpp
@@ -1,8 +1,8 @@
+#include <cmath>
 #include "InverseKinematicsV2IPOPT.h"
 #include <iDynTree/Core/EigenHelpers.h>
 #include <string>
 #include <vector>
-#include <cmath>
 #include <cassert>
 
 using namespace std;

--- a/inverse-kinematics/tests/CMakeLists.txt
+++ b/inverse-kinematics/tests/CMakeLists.txt
@@ -14,6 +14,10 @@ target_link_libraries(InverseKinematicsTest human-ik ${iDynTree_LIBRARIES})
 add_test(NAME testIK
         COMMAND ${PROJECT_NAME})
 
+if (MSVC)
+  target_compile_definitions(testIK PRIVATE -D_USE_MATH_DEFINES)
+endif ()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 find_package (Matio)

--- a/inverse-kinematics/tests/testIK.cpp
+++ b/inverse-kinematics/tests/testIK.cpp
@@ -1,4 +1,4 @@
-
+#include <cmath>
 #include <human-ik/InverseKinematics.h>
 
 #include "URDFdir.h"


### PR DESCRIPTION
Hi guys, 
please review and merge this pull request.

Main changes:
- add _USE_MATH_DEFINES and move math include on top of the file to fix build on Windows.
- fix the bug in the initialisation of the base orientation quaternion which caused rviz to rise errors about the quaternion format when keeping the default base orientation.

As side comment, I think we can keep as good practice placing on the top the _USE_MATH_DEFINE definition and cmath inclusion also for the other files and other projects which needs to be multiplatform (aka build also on Windows).  @francesco-romano c.c. @diegoferigo  @traversaro