### PR TITLE
Update HDE to work with iDynTree 0.8

### DIFF
--- a/human-dynamics-estimator/include/HumanDynamicsEstimator.h
+++ b/human-dynamics-estimator/include/HumanDynamicsEstimator.h
@@ -94,10 +94,10 @@ class HumanDynamicsEstimator : public yarp::os::RFModule {
     } m_inputOutputMapping;
 
     // Priors on regularization, measurements and dynamics constraints
-    iDynTree::SparseMatrix m_priorDynamicsConstraintsCovarianceInverse; // Sigma_D^-1
-    iDynTree::SparseMatrix m_priorDynamicsRegularizationCovarianceInverse; // Sigma_d^-1
+    iDynTree::SparseMatrix<iDynTree::ColumnMajor> m_priorDynamicsConstraintsCovarianceInverse; // Sigma_D^-1
+    iDynTree::SparseMatrix<iDynTree::ColumnMajor> m_priorDynamicsRegularizationCovarianceInverse; // Sigma_d^-1
     iDynTree::VectorDynSize m_priorDynamicsRegularizationExpectedValue; // mu_d
-    iDynTree::SparseMatrix m_priorMeasurementsCovarianceInverse; // Sigma_y^-1
+    iDynTree::SparseMatrix<iDynTree::ColumnMajor>  m_priorMeasurementsCovarianceInverse; // Sigma_y^-1
 
     // Measurements vector
     iDynTree::VectorDynSize m_measurements;
@@ -109,7 +109,7 @@ class HumanDynamicsEstimator : public yarp::os::RFModule {
     // E[p(d|y)]: Expected value of A posteriori probability.
     iDynTree::VectorDynSize m_expectedDynamicsAPosteriori;
 //    iDynTree::SparseMatrix m_covarianceDynamicsAPosterioriInverse;
-    Eigen::SparseMatrix<double, Eigen::RowMajor> m_covarianceDynamicsAPosterioriInverse;
+    Eigen::SparseMatrix<double, Eigen::ColMajor> m_covarianceDynamicsAPosterioriInverse;
 
     /*! Full linear system matrices and vectors
      * \f[
@@ -118,19 +118,19 @@ class HumanDynamicsEstimator : public yarp::os::RFModule {
      * \begin{bmatrix} 0 \\ y \end{bmatrix}
      * \f]
      */
-    iDynTree::SparseMatrix m_dynamicsConstraintsMatrix;
+    iDynTree::SparseMatrix<iDynTree::ColumnMajor> m_dynamicsConstraintsMatrix;
     iDynTree::VectorDynSize m_dynamicsConstraintsBias;
-    iDynTree::SparseMatrix m_measurementsMatrix;
+    iDynTree::SparseMatrix<iDynTree::ColumnMajor> m_measurementsMatrix;
     iDynTree::VectorDynSize m_measurementsBias;
 
     struct {
         // Decompositions of covariance matrices
 //        Eigen::SimplicialLDLT<Eigen::SparseMatrix<double, Eigen::RowMajor> > covarianceDynamicsPriorInverseDecomposition;
 //        Eigen::SimplicialLDLT<Eigen::SparseMatrix<double, Eigen::RowMajor> > covarianceDynamicsAPosterioriInverseDecomposition;
-        Eigen::SparseLU<Eigen::SparseMatrix<double, Eigen::RowMajor> > covarianceDynamicsPriorInverseDecomposition;
-        Eigen::SparseLU<Eigen::SparseMatrix<double, Eigen::RowMajor> > covarianceDynamicsAPosterioriInverseDecomposition;
+        Eigen::SparseLU<Eigen::SparseMatrix<double, Eigen::ColMajor> > covarianceDynamicsPriorInverseDecomposition;
+        Eigen::SparseLU<Eigen::SparseMatrix<double, Eigen::ColMajor> > covarianceDynamicsAPosterioriInverseDecomposition;
 
-        Eigen::SparseMatrix<double, Eigen::RowMajor> covarianceDynamicsPriorInverse;
+        Eigen::SparseMatrix<double, Eigen::ColMajor> covarianceDynamicsPriorInverse;
 //        iDynTree::SparseMatrix covarianceDynamicsPriorInverse;
 
         iDynTree::VectorDynSize expectedDynamicsPrior;

--- a/human-dynamics-estimator/src/HumanDynamicsEstimator.cpp
+++ b/human-dynamics-estimator/src/HumanDynamicsEstimator.cpp
@@ -22,7 +22,7 @@ static bool parseFrameListOption(const yarp::os::Value &option, std::vector<std:
 static bool parseMeasurementsPriorsOption(const yarp::os::Bottle& priorsGroup,
                                           const iDynTree::BerdyHelper& berdy,
                                           const std::string& optionPrefix,
-                                          iDynTree::SparseMatrix& parseMatrix);
+                                          iDynTree::SparseMatrix<iDynTree::ColumnMajor>& parseMatrix);
 static bool parseCovarianceMatrixOption(const yarp::os::Value &option, size_t expectedMatrixSize, iDynTree::Triplets &parsedMatrix);
 
 
@@ -673,7 +673,7 @@ static bool parseFrameListOption(const yarp::os::Value &option, std::vector<std:
 static bool parseMeasurementsPriorsOption(const yarp::os::Bottle& priorsGroup,
                                           const iDynTree::BerdyHelper& berdy,
                                           const std::string& optionPrefix,
-                                          iDynTree::SparseMatrix& parsedMatrix)
+                                          iDynTree::SparseMatrix<iDynTree::ColumnMajor>& parsedMatrix)
 {
     using std::pair;
     using std::string;


### PR DESCRIPTION
This needs to be tested, as we converted all the matrices from RowMajor to ColumnMajor to be compatible with the new `iDynTree::BerdyHelper` interface. 