### PR TITLE
Improve human state provider

### DIFF
--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -23,7 +23,8 @@ yarp_install(FILES ${HDE_APP_FILES} DESTINATION ${YARP_APPLICATIONS_INSTALL_DIR}
 # Install robot urdf files
 set(ROBOT_URDF_FILES urdfs/iCubGenova02.urdf
                urdfs/iCubGenova04.urdf
-               urdfs/iCubGazeboV2_5.urdf)
+               urdfs/iCubGazeboV2_5.urdf
+	       urdfs/teleoperation_iCub_model_V_2_5.urdf)
 
 yarp_install(FILES ${ROBOT_URDF_FILES}
              DESTINATION ${YARP_CONTEXTS_INSTALL_DIR}/human-dynamic-estimation/urdfs)

--- a/conf/ros/rviz/iCubRviz.rviz
+++ b/conf/ros/rviz/iCubRviz.rviz
@@ -5,7 +5,7 @@ Panels:
     Property Tree Widget:
       Expanded: ~
       Splitter Ratio: 0.5099999904632568
-    Tree Height: 331
+    Tree Height: 700
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -25,17 +25,21 @@ Panels:
     Name: Time
     SyncMode: 0
     SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
 Visualization Manager:
   Class: ""
   Displays:
     - Alpha: 0.5
       Cell Size: 1
       Class: rviz/Grid
-      Color: 160; 160; 164
+      Color: 186; 189; 182
       Enabled: true
       Line Style:
         Line Width: 0.029999999329447746
-        Value: Lines
+        Value: Billboards
       Name: Grid
       Normal Cell Count: 0
       Offset:
@@ -43,7 +47,7 @@ Visualization Manager:
         Y: 0
         Z: 0
       Plane: XY
-      Plane Cell Count: 10
+      Plane Cell Count: 1000
       Reference Frame: <Fixed Frame>
       Value: true
     - Alpha: 1
@@ -65,19 +69,11 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        chest_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         head:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        head_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         imu_frame:
           Alpha: 1
           Show Axes: false
@@ -106,20 +102,12 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        l_foot_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         l_forearm:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
         l_forearm_dh_frame:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-        l_forearm_fake:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -228,10 +216,6 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        l_hand_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         l_hip_1:
           Alpha: 1
           Show Axes: false
@@ -252,10 +236,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        l_lower_leg_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         l_shoulder_1:
           Alpha: 1
           Show Axes: false
@@ -380,10 +360,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        l_upper_arm_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         l_upper_leg:
           Alpha: 1
           Show Axes: false
@@ -394,10 +370,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
         l_upper_leg_dh_frame:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-        l_upper_leg_fake:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -440,20 +412,12 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        r_foot_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         r_forearm:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
         r_forearm_dh_frame:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-        r_forearm_fake:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -562,10 +526,6 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        r_hand_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         r_hip_1:
           Alpha: 1
           Show Axes: false
@@ -586,10 +546,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        r_lower_leg_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         r_lower_leg_skin_0:
           Alpha: 1
           Show Axes: false
@@ -866,10 +822,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        r_upper_arm_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         r_upper_leg:
           Alpha: 1
           Show Axes: false
@@ -883,10 +835,6 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        r_upper_leg_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         r_wrist_1:
           Alpha: 1
           Show Axes: false
@@ -897,10 +845,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        root_link_fake:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         torso_1:
           Alpha: 1
           Show Axes: false
@@ -919,10 +863,10 @@ Visualization Manager:
       Visual Enabled: true
   Enabled: true
   Global Options:
-    Background Color: 0; 60; 88
+    Background Color: 255; 255; 255
     Default Light: true
     Fixed Frame: ground
-    Frame Rate: 30
+    Frame Rate: 60
   Name: root
   Tools:
     - Class: rviz/Interact
@@ -932,7 +876,10 @@ Visualization Manager:
     - Class: rviz/FocusCamera
     - Class: rviz/Measure
     - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
       Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
     - Class: rviz/SetGoal
       Topic: /move_base_simple/goal
     - Class: rviz/PublishPoint
@@ -942,33 +889,33 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 19.909801483154297
+      Distance: 2.785710096359253
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: -6.590195655822754
-        Y: -0.21359369158744812
-        Z: -1.8191369771957397
-      Focal Shape Fixed Size: true
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: false
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.29065075516700745
-      Target Frame: <Fixed Frame>
+      Pitch: 0.20039872825145721
+      Target Frame: Robot/base_link
       Value: Orbit (rviz)
-      Yaw: 6.268116474151611
+      Yaw: 2.655397653579712
     Saved: ~
 Window Geometry:
   Displays:
-    collapsed: false
-  Height: 650
-  Hide Left Dock: false
+    collapsed: true
+  Height: 1025
+  Hide Left Dock: true
   Hide Right Dock: true
-  QMainWindow State: 000000ff00000000fd00000004000000000000015d00000202fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006200fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002c00000202000000e300fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000388fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003a00000388000000c600fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000046c00000040fc0100000002fb0000000800540069006d006501000000000000046c0000022000fffffffb0000000800540069006d006501000000000000045000000000000000000000030e0000020200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000015d00000361fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073000000003d00000361000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000020600000361fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000361000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000078000000040fc0100000002fb0000000800540069006d0065010000000000000780000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000007800000036100000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -977,6 +924,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: true
-  Width: 1132
-  X: 157
-  Y: 109
+  Width: 1920
+  X: 0
+  Y: 27

--- a/conf/urdfs/Claudia48DoF_Dec2017.urdf
+++ b/conf/urdfs/Claudia48DoF_Dec2017.urdf
@@ -1,0 +1,1309 @@
+<robot name="XSensStyleModel_template">
+<!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
+    <!--LINKS-->
+	<!--Link base (1)-->
+	<link name="Pelvis">
+        <inertial>
+            <mass value="4.88"/>
+			<!--COM origin wrt pHipOrigin-->
+            <origin xyz="0           0    0.050194" rpy="0 0 0" />
+            <inertia ixx="0.029296" iyy="0.011839" izz="0.033081" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt pHipOrigin-->
+            <origin xyz="0           0    0.050194" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1386     0.24927    0.099515"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt pHipOrigin-->
+            <origin xyz="0           0    0.050194" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1386     0.24927    0.099515"/>
+            </geometry>
+        </collision>
+
+    </link>
+    <!--Chain from (2) to (7)-->
+	<link name="L5_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="L5">
+        <inertial>
+            <mass value="6.222"/>
+			<!--COM origin wrt jL5S1-->
+            <origin xyz="0           0     0.04987" rpy="0 0 0" />
+            <inertia ixx="0.019063" iyy="0.015119" izz="0.0002671" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin origin wrt jL5S1-->
+            <origin xyz="0           0     0.04987" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1386     0.16376    0.099741"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin origin wrt jL5S1-->
+            <origin xyz="0           0     0.04987" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1386     0.16376    0.099741"/>
+            </geometry>
+        </collision>
+    </link>
+	<link name="L3_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="L3">
+        <inertial>
+            <mass value="6.222"/>
+			<!--COM origin wrt jL4L3-->
+            <origin xyz="0           0    0.045056" rpy="0 0 0" />
+            <inertia ixx="0.018115" iyy="0.014171" izz="0.023865" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin origin wrt jL4L3-->
+            <origin xyz="0           0    0.045056" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1386     0.16376    0.090113"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin origin wrt jL4L3-->
+            <origin xyz="0           0    0.045056" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1386     0.16376    0.090113"/>
+            </geometry>
+        </collision>
+    </link>
+	<link name="T12_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="T12">
+        <inertial>
+            <mass value="6.222"/>
+			<!--COM origin wrt jL1T12-->
+            <origin xyz="0           0    0.045056" rpy="0 0 0" />
+            <inertia ixx="0.018115" iyy="0.014171" izz="0.023865" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin origin wrt jL1T12-->
+            <origin xyz="0           0    0.045056" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1386     0.16376    0.090113"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin origin wrt jL1T12-->
+            <origin xyz="0           0    0.045056" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1386     0.16376    0.090113"/>
+            </geometry>
+        </collision>
+    </link>
+	<link name="T8_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="T8_f2">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="T8">
+        <inertial>
+            <mass value="2.44"/>
+			<!--COM origin wrt jT9T8-->
+            <origin xyz="0           0    0.062925" rpy="0 0 0" />
+            <inertia ixx="0.0038182" iyy="0.007132" izz="0.0045093" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jT9T8-->
+            <origin xyz="0           0    0.062925" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1387    0.054218     0.12585"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jT9T8-->
+            <origin xyz="0           0    0.062925" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1387    0.054218     0.12585"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<link name="Neck_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="Neck_f2">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="Neck">
+        <inertial>
+            <mass value="0.732"/>
+			<!--COM origin wrt jT1C7-->
+            <origin xyz="0           0    0.041973" rpy="0 0 0" />
+            <inertia ixx="0.00056618" iyy="0.00056618" izz="0.00027264" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jT1C7-->
+            <origin xyz="0           0    0.041973" rpy="0 0 0" />
+            <geometry>
+		<cylinder length="0.083946" radius="0.013647"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jT1C7-->
+            <origin xyz="0           0    0.041973" rpy="0 0 0" />
+            <geometry>
+                <cylinder length="0.083946" radius="0.013647"/>
+            </geometry>
+        </collision>
+    </link>
+	<link name="Head_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="Head">
+        <inertial>
+            <mass value="2.196"/>
+			<!--COM origin wrt jC1Head-->
+            <origin xyz="0           0    0.079896" rpy="0 0 0" />
+            <inertia ixx="0.0056072" iyy="0.0056072" izz="0.0056072" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--boc origin wrt jC1Head-->
+            <origin xyz="0           0    0.079896" rpy="0 0 0" />
+            <geometry>
+                <sphere radius="0.079896"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jC1Head-->
+            <origin xyz="0           0    0.079896" rpy="0 0 0" />
+            <geometry>
+                <sphere radius="0.079896"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<!--Chain from (8) to (11)-->
+	<link name="RightShoulder">
+        <inertial>
+            <mass value="1.891"/>
+			<!--COM origin wrt jRightC7Shoulder-->
+            <origin xyz="0   -0.064947           0" rpy="0 0 0" />
+            <inertia ixx="0.0029192" iyy="0.00052075" izz="0.0029192" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jRightC7Shoulder. RPY rotated of pi/2.-->
+            <origin xyz="0   -0.064947           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.12989" radius="0.023468"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jRightC7Shoulder. RPY rotated of pi/2.-->
+            <origin xyz="0   -0.064947           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.12989" radius="0.023468"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<link name="RightUpperArm_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="RightUpperArm_f2">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+    <link name="RightUpperArm">
+        <inertial>
+            <mass value="1.83"/>
+			<!--COM origin wrt jRightShoulder-->
+            <origin xyz="0    -0.13498           0" rpy="0 0 0" />
+            <inertia ixx="0.01151" iyy="0.00079302" izz="0.01151" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jRightShoulder. RPY rotated of pi/2.-->
+            <origin xyz="0    -0.13498           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.26995" radius="0.02944"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jRightShoulder. RPY rotated of pi/2.-->
+            <origin xyz="0    -0.13498           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.26995" radius="0.02944"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<link name="RightForeArm_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="RightForeArm">
+        <inertial>
+            <mass value="1.22"/>
+			<!--COM origin wrt jRightElbow-->
+            <origin xyz="0    -0.11119           0" rpy="0 0 0" />
+            <inertia ixx="0.0051448" iyy="0.00023497" izz="0.0051448" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jRightElbow. RPY rotated of pi/2.-->
+            <origin xyz="0    -0.11119           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.22237" radius="0.019626"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jRightElbow. RPY rotated of pi/2.-->
+            <origin xyz="0    -0.11119           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.22237" radius="0.019626"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<link name="RightHand_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="RightHand">
+        <inertial>
+            <mass value="0.366"/>
+			<!--COM origin wrt jRightWrist-->
+            <origin xyz="0   -0.083494           0" rpy="0 0 0" />
+            <inertia ixx="0.0008975" iyy="0.00042499" izz="0.0012285" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jRightWrist-->
+            <origin xyz="0   -0.083494           0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.11133     0.16699    0.039253"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jRightWrist-->
+            <origin xyz="0   -0.083494           0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.11133     0.16699    0.039253"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<!--Chain from (12) to (15)-->
+	<link name="LeftShoulder">
+        <inertial>
+            <mass value="1.891"/>
+			<!--COM origin wrt jLeftC7Shoulder-->
+            <origin xyz="0    0.064947           0" rpy="0 0 0" />
+            <inertia ixx="0.0029192" iyy="0.00052075" izz="0.0029192" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jLeftC7Shoulder. RPY rotated of pi/2.-->
+            <origin xyz="0    0.064947           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.12989" radius="0.023468"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jLeftC7Shoulder. RPY rotated of pi/2.-->
+            <origin xyz="0    0.064947           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.12989" radius="0.023468"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<link name="LeftUpperArm_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="LeftUpperArm_f2">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="LeftUpperArm">
+        <inertial>
+            <mass value="1.83"/>
+			<!--COM origin wrt jLeftShoulder-->
+            <origin xyz="0     0.13498           0" rpy="0 0 0" />
+            <inertia ixx="0.01151" iyy="0.00079302" izz="0.01151" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jLeftShoulder. RPY rotated of pi/2.-->
+            <origin xyz="0     0.13498           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.26995" radius="0.02944"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jLeftShoulder. RPY rotated of pi/2.-->
+            <origin xyz="0     0.13498           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.26995" radius="0.02944"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<link name="LeftForeArm_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="LeftForeArm">
+        <inertial>
+            <mass value="1.22"/>
+			<!--COM origin wrt jLeftElbow-->
+            <origin xyz="0     0.11119           0" rpy="0 0 0" />
+            <inertia ixx="0.0051448" iyy="0.00023497" izz="0.0051448" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jLeftElbow. RPY rotated of pi/2.-->
+            <origin xyz="0     0.11119           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.22237" radius="0.019626"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jLeftElbow. RPY rotated of pi/2.-->
+            <origin xyz="0     0.11119           0" rpy="1.5708 0 0" />
+            <geometry>
+                <cylinder length="0.22237" radius="0.019626"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<link name="LeftHand_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="LeftHand">
+        <inertial>
+            <mass value="0.366"/>
+			<!--COM origin wrt jLeftWrist-->
+            <origin xyz="0    0.083494           0" rpy="0 0 0" />
+            <inertia ixx="0.0008975" iyy="0.00042499" izz="0.0012285" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--COM origin wrt jLeftWrist-->
+            <origin xyz="0    0.083494           0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.11133     0.16699    0.039253"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--COM origin wrt jLeftWrist-->
+            <origin xyz="0    0.083494           0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.11133     0.16699    0.039253"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<!--Chain from (16) to (19)-->
+	<link name="RightUpperLeg_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="RightUpperLeg_f2">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+    <link name="RightUpperLeg">
+        <inertial>
+            <mass value="7.625"/>
+			<!--COM origin wrt jRightHip-->
+            <origin xyz="0           0    -0.22557" rpy="0 0 0" />
+            <inertia ixx="0.13545" iyy="0.13545" izz="0.012254" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jRightHip-->
+            <origin xyz="0           0    -0.22557" rpy="0 0 0" />
+            <geometry>
+                <cylinder length="0.45113" radius="0.056694"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jRightHip-->
+            <origin xyz="0           0    -0.22557" rpy="0 0 0" />
+            <geometry>
+                <cylinder length="0.45113" radius="0.056694"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<link name="RightLowerLeg_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+    <link name="RightLowerLeg">
+        <inertial>
+            <mass value="2.2265"/>
+			<!--COM origin wrt jRightKnee-->
+            <origin xyz="0           0    -0.20314" rpy="0 0 0" />
+            <inertia ixx="0.031404" iyy="0.031404" izz="0.001557" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jRightKnee-->
+            <origin xyz="0           0    -0.20314" rpy="0 0 0" />
+            <geometry>
+                <cylinder length="0.40628" radius="0.037398"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jRightKnee-->
+            <origin xyz="0           0    -0.20314" rpy="0 0 0" />
+            <geometry>
+                <cylinder length="0.40628" radius="0.037398"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<link name="RightFoot_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="RightFoot_f2">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+    <link name="RightFoot">
+        <inertial>
+            <mass value="0.793"/>
+			<!--COM origin wrt jRightAnkle-->
+            <origin xyz="0.050643           0   -0.061735" rpy="0 0 0" />
+            <inertia ixx="0.0013771" iyy="0.00317" izz="0.0025323" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jRightAnkle-->
+	    	<origin xyz="0.050643           0   -0.061735" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1809    0.074795     0.12347"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jRightAnkle-->
+		    <origin xyz="0.050643           0   -0.061735" rpy="0 0 0" />
+	            <geometry>
+	                <box size="0.1809    0.074795     0.12347"/>
+	            </geometry>
+        </collision>
+
+    </link>
+    <link name="RightToe">
+        <inertial>
+            <mass value="0.0915"/>
+			<!--COM origin wrt jRightBallFoot-->
+            <origin xyz="0.029551           0           0" rpy="0 0 0" />
+            <inertia ixx="4.419e-05" iyy="2.8167e-05" izz="6.929e-05" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jRightBallFoot-->
+            <origin xyz="0.029551           0           0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.059101    0.074795    0.014183"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jRightBallFoot-->
+            <origin xyz="0.029551           0           0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.059101    0.074795    0.014183"/>
+            </geometry>
+        </collision>
+    </link>
+	<!--Chain from (20) to (23)-->
+	<link name="LeftUpperLeg_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="LeftUpperLeg_f2">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+    <link name="LeftUpperLeg">
+        <inertial>
+            <mass value="7.625"/>
+			<!--COM origin wrt jLeftHip-->
+            <origin xyz="0           0    -0.22557" rpy="0 0 0" />
+            <inertia ixx="0.13545" iyy="0.13545" izz="0.012254" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jLeftHip-->
+            <origin xyz="0           0    -0.22557" rpy="0 0 0" />
+            <geometry>
+                <cylinder length="0.45113" radius="-0.056694"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jLeftHip-->
+            <origin xyz="0           0    -0.22557" rpy="0 0 0" />
+            <geometry>
+                <cylinder length="0.45113" radius="-0.056694"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<link name="LeftLowerLeg_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="LeftLowerLeg">
+        <inertial>
+            <mass value="2.2265"/>
+			<!--COM origin wrt jLeftKnee-->
+            <origin xyz="0           0    -0.20314" rpy="0 0 0" />
+            <inertia ixx="0.031404" iyy="0.031404" izz="0.001557" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jLeftKnee-->
+            <origin xyz="0           0    -0.20314" rpy="0 0 0" />
+            <geometry>
+		<cylinder length="0.40628" radius="0.037398"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jLeftKnee-->
+            <origin xyz="0           0    -0.20314" rpy="0 0 0" />
+            <geometry>
+		<cylinder length="0.40628" radius="0.037398"/>
+            </geometry>
+        </collision>
+
+    </link>
+	<link name="LeftFoot_f1">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+	<link name="LeftFoot_f2">
+        <inertial>
+            <mass value="0"/>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <inertia ixx="0" iyy="0" izz="0" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+    </link>
+    <link name="LeftFoot">
+        <inertial>
+            <mass value="0.793"/>
+			<!--COM origin wrt jLeftAnkle-->
+            <origin xyz="0.050643           0   -0.061735" rpy="0 0 0" />
+            <inertia ixx="0.0013771" iyy="0.00317" izz="0.0025323" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jLeftAnkle-->
+	   	 	<origin xyz="0.050643           0   -0.061735" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1809    0.074795     0.12347"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jLeftAnkle-->
+		    <origin xyz="0.050643           0   -0.061735" rpy="0 0 0" />
+	            <geometry>
+	                <box size="0.1809    0.074795     0.12347"/>
+	            </geometry>
+        </collision>
+
+    </link>
+	<link name="LeftToe">
+        <inertial>
+            <mass value="0.0915"/>
+			<!--COM origin wrt jLeftBallFoot-->
+            <origin xyz="0.029551           0           0" rpy="0 0 0" />
+            <inertia ixx="4.419e-05" iyy="2.8167e-05" izz="6.929e-05" ixy="0" ixz="0" iyz="0"/>
+        </inertial>
+
+        <visual>
+			<!--box origin wrt jLeftBallFoot-->
+            <origin xyz="0.029551           0           0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.059101    0.074795    0.014183"/>
+            </geometry>
+        </visual>
+
+        <collision>
+			<!--box origin wrt jLeftBallFoot-->
+            <origin xyz="0.029551           0           0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.059101    0.074795    0.014183"/>
+            </geometry>
+        </collision>
+    </link>
+
+
+	<!--JOINTS-->
+	<!--Chain from (2) to (7)-->
+	<joint name="jL5S1_rotx" type="revolute">
+        <origin xyz="-8.9e-05           0    0.099951" rpy="0 0 0"/>
+        <parent link="Pelvis"/>
+        <child link="L5_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.610865" upper="0.610865" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jL5S1_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="L5_f1"/>
+        <child link="L5"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.523599" upper="1.309" />
+        <axis xyz="0 1 0" />
+    </joint>
+	<joint name="jL4L3_rotx" type="revolute">
+        <origin xyz="0.000162           0    0.099741" rpy="0 0 0"/>
+        <parent link="L5"/>
+        <child link="L3_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.610865" upper="0.610865" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jL4L3_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="L3_f1"/>
+        <child link="L3"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.523599" upper="1.309" />
+        <axis xyz="0 1 0" />
+    </joint>
+	<joint name="jL1T12_rotx" type="revolute">
+        <origin xyz="0           0    0.090113" rpy="0 0 0"/>
+        <parent link="L3"/>
+        <child link="T12_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.610865" upper="0.610865" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jL1T12_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="T12_f1"/>
+        <child link="T12"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.523599" upper="1.309" />
+        <axis xyz="0 1 0" />
+    </joint>
+	<joint name="jT9T8_rotx" type="revolute">
+        <origin xyz="0           0    0.090113" rpy="0 0 0"/>
+        <parent link="T12"/>
+        <child link="T8_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.349066" upper="0.349066" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jT9T8_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="T8_f1"/>
+        <child link="T8_f2"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.261799" upper="0.698132" />
+        <axis xyz="0 1 0" />
+    </joint>
+    <joint name="jT9T8_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="T8_f2"/>
+        <child link="T8"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.610865" upper="0.610865" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<joint name="jT1C7_rotx" type="revolute">
+        <origin xyz="0           0     0.12585" rpy="0 0 0"/>
+        <parent link="T8"/>
+        <child link="Neck_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.610865" upper="0.610865" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jT1C7_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="Neck_f1"/>
+        <child link="Neck_f2"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.959931" upper="1.5708" />
+        <axis xyz="0 1 0" />
+    </joint>
+    <joint name="jT1C7_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="Neck_f2"/>
+        <child link="Neck"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-1.22173" upper="1.22173" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<joint name="jC1Head_rotx" type="revolute">
+        <origin xyz="0.000384           0    0.083946" rpy="0 0 0"/>
+        <parent link="Neck"/>
+        <child link="Head_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.610865" upper="0.610865" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jC1Head_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="Head_f1"/>
+        <child link="Head"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.436332" upper="0.174533" />
+        <axis xyz="0 1 0" />
+    </joint>
+	<!--Chain from (8) to (11)-->
+	<joint name="jRightC7Shoulder_rotx" type="revolute">
+        <origin xyz="0   -0.027109    0.070322" rpy="0 0 0"/>
+        <parent link="T8"/>
+        <child link="RightShoulder"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.0872665" upper="0.785398" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jRightShoulder_rotx" type="revolute">
+        <origin xyz="0    -0.12989           0" rpy="0 0 0"/>
+        <parent link="RightShoulder"/>
+        <child link="RightUpperArm_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-2.35619" upper="1.5708" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jRightShoulder_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="RightUpperArm_f1"/>
+        <child link="RightUpperArm_f2"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-1.5708" upper="1.5708" />
+        <axis xyz="0 1 0" />
+    </joint>
+    <joint name="jRightShoulder_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="RightUpperArm_f2"/>
+        <child link="RightUpperArm"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.785398" upper="3.14159" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<joint name="jRightElbow_roty" type="revolute">
+        <origin xyz="0    -0.26995           0" rpy="0 0 0"/>
+        <parent link="RightUpperArm"/>
+        <child link="RightForeArm_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-1.5708" upper="1.48353" />
+        <axis xyz="0 1 0" />
+    </joint>
+	<joint name="jRightElbow_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="RightForeArm_f1"/>
+        <child link="RightForeArm"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="0" upper="2.53073" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<joint name="jRightWrist_rotx" type="revolute">
+        <origin xyz="7.3e-05    -0.22237           0" rpy="0 0 0"/>
+        <parent link="RightForeArm"/>
+        <child link="RightHand_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.872665" upper="1.0472" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jRightWrist_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="RightHand_f1"/>
+        <child link="RightHand"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.523599" upper="0.349066" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<!--Chain from (12) to (15)-->
+	<joint name="jLeftC7Shoulder_rotx" type="revolute">
+        <origin xyz="0    0.027109    0.070322" rpy="0 0 0"/>
+        <parent link="T8"/>
+        <child link="LeftShoulder"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.0872665" upper="0.785398" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jLeftShoulder_rotx" type="revolute">
+        <origin xyz="0     0.12989           0" rpy="0 0 0"/>
+        <parent link="LeftShoulder"/>
+        <child link="LeftUpperArm_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-1.5708" upper="2.35619" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jLeftShoulder_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="LeftUpperArm_f1"/>
+        <child link="LeftUpperArm_f2"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-1.5708" upper="1.5708" />
+        <axis xyz="0 1 0" />
+    </joint>
+    <joint name="jLeftShoulder_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="LeftUpperArm_f2"/>
+        <child link="LeftUpperArm"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-3.14159" upper="0.785398" />
+        <axis xyz="0 0 1" />
+    </joint>
+    <joint name="jLeftElbow_roty" type="revolute">
+        <origin xyz="0     0.26995           0" rpy="0 0 0"/>
+        <parent link="LeftUpperArm"/>
+        <child link="LeftForeArm_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-1.5708" upper="1.48353" />
+        <axis xyz="0 1 0" />
+    </joint>
+    <joint name="jLeftElbow_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="LeftForeArm_f1"/>
+        <child link="LeftForeArm"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-2.53073" upper="0" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<joint name="jLeftWrist_rotx" type="revolute">
+        <origin xyz="7.3e-05     0.22237           0" rpy="0 0 0"/>
+        <parent link="LeftForeArm"/>
+        <child link="LeftHand_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-1.0472" upper="0.872665" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jLeftWrist_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="LeftHand_f1"/>
+        <child link="LeftHand"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.349066" upper="0.523599" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<!--Chain from (16) to (19)-->
+	<joint name="jRightHip_rotx" type="revolute">
+        <origin xyz="4.4e-05   -0.081879    0.000436" rpy="0 0 0"/>
+        <parent link="Pelvis"/>
+        <child link="RightUpperLeg_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.523599" upper="0.785398" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jRightHip_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="RightUpperLeg_f1"/>
+        <child link="RightUpperLeg_f2"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <axis xyz="0 1 0" />
+    </joint>
+    <joint name="jRightHip_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="RightUpperLeg_f2"/>
+        <child link="RightUpperLeg"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.785398" upper="0.785398" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<joint name="jRightKnee_roty" type="revolute">
+        <origin xyz="6.7e-05           0    -0.45113" rpy="0 0 0"/>
+        <parent link="RightUpperLeg"/>
+        <child link="RightLowerLeg_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="0" upper="2.35619" />
+        <axis xyz="0 1 0" />
+    </joint>
+	<joint name="jRightKnee_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="RightLowerLeg_f1"/>
+        <child link="RightLowerLeg"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.698132" upper="0.523599" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<joint name="jRightAnkle_rotx" type="revolute">
+        <origin xyz="0.000289           0    -0.40628" rpy="0 0 0"/>
+        <parent link="RightLowerLeg"/>
+        <child link="RightFoot_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.610865" upper="0.785398" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jRightAnkle_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="RightFoot_f1"/>
+        <child link="RightFoot_f2"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.523599" upper="0.872665" />
+        <axis xyz="0 1 0" />
+    </joint>
+    <joint name="jRightAnkle_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="RightFoot_f2"/>
+        <child link="RightFoot"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.436332" upper="0.872665" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<joint name="jRightBallFoot_roty" type="revolute">
+        <origin xyz="0.14109           0    -0.10944" rpy="0 0 0"/>
+        <parent link="RightFoot"/>
+        <child link="RightToe"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.174533" upper="1.5708" />
+        <axis xyz="0 1 0" />
+    </joint>
+	<!--Chain from (20) to (23)-->
+	<joint name="jLeftHip_rotx" type="revolute">
+        <origin xyz="4.4e-05    0.081879    0.000436" rpy="0 0 0"/>
+        <parent link="Pelvis"/>
+        <child link="LeftUpperLeg_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.523599" upper="0.785398" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jLeftHip_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="LeftUpperLeg_f1"/>
+        <child link="LeftUpperLeg_f2"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <axis xyz="0 1 0" />
+    </joint>
+    <joint name="jLeftHip_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="LeftUpperLeg_f2"/>
+        <child link="LeftUpperLeg"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.785398" upper="0.785398" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<joint name="jLeftKnee_roty" type="revolute">
+        <origin xyz="6.7e-05           0    -0.45113" rpy="0 0 0"/>
+        <parent link="LeftUpperLeg"/>
+        <child link="LeftLowerLeg_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="0" upper="2.35619" />
+        <axis xyz="0 1 0" />
+    </joint>
+    <joint name="jLeftKnee_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="LeftLowerLeg_f1"/>
+        <child link="LeftLowerLeg"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.523599" upper="0.698132" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<joint name="jLeftAnkle_rotx" type="revolute">
+        <origin xyz="0.000289           0    -0.40628" rpy="0 0 0"/>
+        <parent link="LeftLowerLeg"/>
+        <child link="LeftFoot_f1"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.610865" upper="0.785398" />
+        <axis xyz="1 0 0" />
+    </joint>
+	<joint name="jLeftAnkle_roty" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="LeftFoot_f1"/>
+        <child link="LeftFoot_f2"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.523599" upper="0.872665" />
+        <axis xyz="0 1 0" />
+    </joint>
+    <joint name="jLeftAnkle_rotz" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <parent link="LeftFoot_f2"/>
+        <child link="LeftFoot"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.872665" upper="0.436332" />
+        <axis xyz="0 0 1" />
+    </joint>
+	<joint name="jLeftBallFoot_roty" type="revolute">
+        <origin xyz="0.14109           0    -0.10944" rpy="0 0 0"/>
+        <parent link="LeftFoot"/>
+        <child link="LeftToe"/>
+        <dynamics damping="0.1" friction="0.0"/>
+        <limit effort="30" velocity="1.0" lower="-0.174533" upper="1.5708" />
+        <axis xyz="0 1 0" />
+    </joint>
+
+	<!-- Sensor  1-->
+<sensor name="Pelvis_gyro" type="gyroscope">
+<parent link="Pelvis"/>
+<origin xyz="-0.057002  0.00018219    0.097365" rpy="0.01645     0.94446     -3.0831"/>
+</sensor>
+<sensor name="Pelvis_accelerometer" type="accelerometer">
+<parent link="Pelvis"/>
+<origin xyz="-0.057002  0.00018219    0.097365" rpy="0.01645     0.94446     -3.0831"/>
+</sensor>
+<!-- Sensor  2-->
+<sensor name="T8_gyro" type="gyroscope">
+<parent link="T8"/>
+<origin xyz="0.12949 -6.4868e-05    0.071109" rpy="-0.039462      1.0551    -0.50407"/>
+</sensor>
+<sensor name="T8_accelerometer" type="accelerometer">
+<parent link="T8"/>
+<origin xyz="0.12949 -6.4868e-05    0.071109" rpy="-0.039462      1.0551    -0.50407"/>
+</sensor>
+<!-- Sensor  3-->
+<sensor name="Head_gyro" type="gyroscope">
+<parent link="Head"/>
+<origin xyz="-0.064019 -3.9764e-05    0.070484" rpy="-2.312    -0.14003      1.0131"/>
+</sensor>
+<sensor name="Head_accelerometer" type="accelerometer">
+<parent link="Head"/>
+<origin xyz="-0.064019 -3.9764e-05    0.070484" rpy="-2.312    -0.14003      1.0131"/>
+</sensor>
+<!-- Sensor  4-->
+<sensor name="RightShoulder_gyro" type="gyroscope">
+<parent link="RightShoulder"/>
+<origin xyz="-0.01879   -0.046896   -0.056309" rpy="0.98009    -0.15308     -1.6935"/>
+</sensor>
+<sensor name="RightShoulder_accelerometer" type="accelerometer">
+<parent link="RightShoulder"/>
+<origin xyz="-0.01879   -0.046896   -0.056309" rpy="0.98009    -0.15308     -1.6935"/>
+</sensor>
+<!-- Sensor  5-->
+<sensor name="RightUpperArm_gyro" type="gyroscope">
+<parent link="RightUpperArm"/>
+<origin xyz="-0.018059   -0.090782    0.018145" rpy="0.5067   -0.066057     -1.4519"/>
+</sensor>
+<sensor name="RightUpperArm_accelerometer" type="accelerometer">
+<parent link="RightUpperArm"/>
+<origin xyz="-0.018059   -0.090782    0.018145" rpy="0.5067   -0.066057     -1.4519"/>
+</sensor>
+<!-- Sensor  6-->
+<sensor name="RightForeArm_gyro" type="gyroscope">
+<parent link="RightForeArm"/>
+<origin xyz="0.0016159    -0.18325    0.018553" rpy="0.38757    -0.26216     -1.4723"/>
+</sensor>
+<sensor name="RightForeArm_accelerometer" type="accelerometer">
+<parent link="RightForeArm"/>
+<origin xyz="0.0016159    -0.18325    0.018553" rpy="0.38757    -0.26216     -1.4723"/>
+</sensor>
+<!-- Sensor  7-->
+<sensor name="RightHand_gyro" type="gyroscope">
+<parent link="RightHand"/>
+<origin xyz="-9.6721e-06   -0.050727    0.018557" rpy="-0.29156    -0.10484     -1.6561"/>
+</sensor>
+<sensor name="RightHand_accelerometer" type="accelerometer">
+<parent link="RightHand"/>
+<origin xyz="-9.6721e-06   -0.050727    0.018557" rpy="-0.29156    -0.10484     -1.6561"/>
+</sensor>
+<!-- Sensor  8-->
+<sensor name="LeftShoulder_gyro" type="gyroscope">
+<parent link="LeftShoulder"/>
+<origin xyz="-0.018761    0.046937   -0.056285" rpy="-0.74206    -0.10355     0.73167"/>
+</sensor>
+<sensor name="LeftShoulder_accelerometer" type="accelerometer">
+<parent link="LeftShoulder"/>
+<origin xyz="-0.018761    0.046937   -0.056285" rpy="-0.74206    -0.10355     0.73167"/>
+</sensor>
+<!-- Sensor  9-->
+<sensor name="LeftUpperArm_gyro" type="gyroscope">
+<parent link="LeftUpperArm"/>
+<origin xyz="-0.018053     0.09068    0.018118" rpy="0.56208    0.046993      1.4058"/>
+</sensor>
+<sensor name="LeftUpperArm_accelerometer" type="accelerometer">
+<parent link="LeftUpperArm"/>
+<origin xyz="-0.018053     0.09068    0.018118" rpy="0.56208    0.046993      1.4058"/>
+</sensor>
+<!-- Sensor  10-->
+<sensor name="LeftForeArm_gyro" type="gyroscope">
+<parent link="LeftForeArm"/>
+<origin xyz="0.0017965     0.18323    0.018292" rpy="1.3227    0.002718      1.1618"/>
+</sensor>
+<sensor name="LeftForeArm_accelerometer" type="accelerometer">
+<parent link="LeftForeArm"/>
+<origin xyz="0.0017965     0.18323    0.018292" rpy="1.3227    0.002718      1.1618"/>
+</sensor>
+<!-- Sensor  11-->
+<sensor name="LeftHand_gyro" type="gyroscope">
+<parent link="LeftHand"/>
+<origin xyz="-5.7104e-05    0.050729    0.018494" rpy="1.0123    -0.25884      1.4668"/>
+</sensor>
+<sensor name="LeftHand_accelerometer" type="accelerometer">
+<parent link="LeftHand"/>
+<origin xyz="-5.7104e-05    0.050729    0.018494" rpy="1.0123    -0.25884      1.4668"/>
+</sensor>
+<!-- Sensor  12-->
+<sensor name="RightUpperLeg_gyro" type="gyroscope">
+<parent link="RightUpperLeg"/>
+<origin xyz="0.012833   -0.047931    -0.27012" rpy="-2.8625      1.3565       1.435"/>
+</sensor>
+<sensor name="RightUpperLeg_accelerometer" type="accelerometer">
+<parent link="RightUpperLeg"/>
+<origin xyz="0.012833   -0.047931    -0.27012" rpy="-2.8625      1.3565       1.435"/>
+</sensor>
+<!-- Sensor  13-->
+<sensor name="RightLowerLeg_gyro" type="gyroscope">
+<parent link="RightLowerLeg"/>
+<origin xyz="0.03074    0.007165    -0.13257" rpy="2.9651       1.436      2.9348"/>
+</sensor>
+<sensor name="RightLowerLeg_accelerometer" type="accelerometer">
+<parent link="RightLowerLeg"/>
+<origin xyz="0.03074    0.007165    -0.13257" rpy="2.9651       1.436      2.9348"/>
+</sensor>
+<!-- Sensor  14-->
+<sensor name="RightFoot_gyro" type="gyroscope">
+<parent link="RightFoot"/>
+<origin xyz="0.081809   0.0016163   -0.011406" rpy="0.35932     0.49173    -0.62413"/>
+</sensor>
+<sensor name="RightFoot_accelerometer" type="accelerometer">
+<parent link="RightFoot"/>
+<origin xyz="0.081809   0.0016163   -0.011406" rpy="0.35932     0.49173    -0.62413"/>
+</sensor>
+<!-- Sensor  15-->
+<sensor name="LeftUpperLeg_gyro" type="gyroscope">
+<parent link="LeftUpperLeg"/>
+<origin xyz="0.011564    0.038074    -0.27007" rpy="-2.9744      1.3823     -1.8185"/>
+</sensor>
+<sensor name="LeftUpperLeg_accelerometer" type="accelerometer">
+<parent link="LeftUpperLeg"/>
+<origin xyz="0.011564    0.038074    -0.27007" rpy="-2.9744      1.3823     -1.8185"/>
+</sensor>
+<!-- Sensor  16-->
+<sensor name="LeftLowerLeg_gyro" type="gyroscope">
+<parent link="LeftLowerLeg"/>
+<origin xyz="0.030907  -0.0068014    -0.13266" rpy="3.0601      1.4623      2.2374"/>
+</sensor>
+<sensor name="LeftLowerLeg_accelerometer" type="accelerometer">
+<parent link="LeftLowerLeg"/>
+<origin xyz="0.030907  -0.0068014    -0.13266" rpy="3.0601      1.4623      2.2374"/>
+</sensor>
+<!-- Sensor  17-->
+<sensor name="LeftFoot_gyro" type="gyroscope">
+<parent link="LeftFoot"/>
+<origin xyz="0.082027   -0.001429    -0.01198" rpy="0.2334     0.65187    -0.66795"/>
+</sensor>
+<sensor name="LeftFoot_accelerometer" type="accelerometer">
+<parent link="LeftFoot"/>
+<origin xyz="0.082027   -0.001429    -0.01198" rpy="0.2334     0.65187    -0.66795"/>
+</sensor>
+
+
+</robot>

--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -190,7 +190,7 @@
 
     <device type="human_wrench_provider" name="HumanWrenchProvider">
         <param name="period">0.100</param>
-        <param name="human_urdf">humanSubject03_66dof.urdf</param>
+        <param name="human_urdf">humanSubject01_66dof.urdf</param>
         <param name="pHRIScenario">false</param>
         <param name="number_of_sources">2</param>
         <param name="sources">(FTShoeLeft FTShoeRight)</param>
@@ -257,7 +257,7 @@
 
     <device type="human_dynamics_estimator" name="HumanDynamicsEstimator">
         <param name="period">0.100</param>
-        <param name="urdf">humanSubject03_66dof.urdf</param>
+        <param name="urdf">humanSubject01_66dof.urdf</param>
         <param name="baseLink">Pelvis</param>
         <param name="number_of_wrench_sensors">2</param>
         <param name="wrench_sensors_link_name">(LeftFoot RightFoot)</param>
@@ -313,7 +313,7 @@
 
     <device type="human_control_board" name="HumanControlBoard">
         <param name="period">0.100</param>
-        <param name="urdf">humanSubject03_66dof.urdf</param>
+        <param name="urdf">humanSubject01_66dof.urdf</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanControlBoardLabel1">HumanStateProvider</elem>

--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -17,11 +17,11 @@
     </device>
 
     <device type="human_state_provider" name="HumanStateProvider">
-        <param name="period">0.100</param>
+        <param name="period">0.02</param>
         <param name="urdf">humanSubject01_66dof.urdf</param>
         <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
-        <param name="ikSolver">pairwised</param>
+        <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>
         <param name="allowIKFailures">true</param>
         <param name="useDirectBaseMeasurement">false</param>
@@ -34,11 +34,21 @@
         <param name="costRegularization">0.000001</param>
         <param name="costTolerance">0.001</param>
         <!-- inverse velocity kinematics parameters -->
+        <!-- inverseVelocityKinematicsSolver values:
+        moorePenrose,
+        completeOrthogonalDecomposition,
+        leastSquare,
+        choleskyDecomposition,
+        sparseCholeskyDecomposition,
+        robustCholeskyDecomposition,
+        sparseRobustCholeskyDecomposition -->
+        <param name='inverseVelocityKinematicsSolver'>sparseRobustCholeskyDecomposition</param>
         <param name="linVelTargetWeight">0.0</param>
         <param name="angVelTargetWeight">1.0</param>
         <!-- integration based IK parameters -->
-        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(0.1 0.1)</param>
-        <param name="integrationBasedIKCorrectionGainsLinRot">(8.0 8.0)</param>
+        <param name='integrationBasedJointVelocityLimit'>10.0</param> <!-- comment or -1.0 for no limits -->
+        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(1.0 1.0)</param>
+        <param name="integrationBasedIKCorrectionGainsLinRot">(8.0 20.0)</param>
         <param name="integrationBasedIKIntegralCorrectionGainsLinRot">(0.0 0.0)</param>
         <group name="MODEL_TO_DATA_LINK_NAMES">
             <param name="map_Pelvis">(Pelvis, XsensSuit::vLink::Pelvis)</param>
@@ -147,8 +157,9 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <!--device type="human_state_wrapper" name="HumanStateWrapper">
-        <param name="period">0.1</param>
+    <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
+    <!-- <device type="human_state_wrapper" name="HumanStateWrapper">
+        <param name="period">0.02</param>
         <param name="outputPort">/HDE/HumanStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
@@ -156,10 +167,10 @@
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device-->
+    </device> -->
 
     <device type="human_state_publisher" name="HumanStatePublisher">
-        <param name="period">0.020</param>
+        <param name="period">0.02</param>
         <param name="baseTFName">/Human/Pelvis</param>
         <param name="humanJointsTopic">/Human/joint_states</param>
         <action phase="startup" level="5" type="attach">
@@ -167,7 +178,7 @@
                 <elem name="HumanStatePublisherLabel">HumanStateProvider</elem>
             </paramlist>
         </action>
-        <action phase="shutdown" level="4" type="detach"/>
+        <action phase="shutdown" level="5" type="detach"/>
     </device>
 
     <device type="iwear_remapper" name="FTSourcesIWearRemapper">

--- a/conf/xml/HumanStateProvider.xml
+++ b/conf/xml/HumanStateProvider.xml
@@ -17,11 +17,11 @@
     </device>
 
     <device type="human_state_provider" name="HumanStateProvider">
-        <param name="period">0.100</param>
+        <param name="period">0.02</param>
         <param name="urdf">humanSubject01_66dof.urdf</param>
         <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
-        <param name="ikSolver">pairwised</param>
+        <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>
         <param name="allowIKFailures">true</param>
         <param name="useDirectBaseMeasurement">false</param>
@@ -34,11 +34,21 @@
         <param name="costRegularization">0.000001</param>
         <param name="costTolerance">0.001</param>
         <!-- inverse velocity kinematics parameters -->
+        <!-- inverseVelocityKinematicsSolver values:
+        moorePenrose,
+        completeOrthogonalDecomposition,
+        leastSquare,
+        choleskyDecomposition,
+        sparseCholeskyDecomposition,
+        robustCholeskyDecomposition,
+        sparseRobustCholeskyDecomposition -->
+        <param name='inverseVelocityKinematicsSolver'>sparseRobustCholeskyDecomposition</param>
         <param name="linVelTargetWeight">0.0</param>
         <param name="angVelTargetWeight">1.0</param>
         <!-- integration based IK parameters -->
-        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(0.1 0.1)</param>
-        <param name="integrationBasedIKCorrectionGainsLinRot">(8.0 8.0)</param>
+        <param name='integrationBasedJointVelocityLimit'>10.0</param> <!-- comment or -1.0 for no limits -->
+        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(1.0 1.0)</param>
+        <param name="integrationBasedIKCorrectionGainsLinRot">(8.0 20.0)</param>
         <param name="integrationBasedIKIntegralCorrectionGainsLinRot">(0.0 0.0)</param>
         <group name="MODEL_TO_DATA_LINK_NAMES">
             <param name="map_Pelvis">(Pelvis, XsensSuit::vLink::Pelvis)</param>
@@ -147,8 +157,9 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <device type="human_state_wrapper" name="HumanStateWrapper">
-        <param name="period">0.1</param>
+    <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
+    <!-- <device type="human_state_wrapper" name="HumanStateWrapper">
+        <param name="period">0.02</param>
         <param name="outputPort">/HDE/HumanStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
@@ -156,10 +167,10 @@
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device>
+    </device> -->
 
     <device type="human_state_publisher" name="HumanStatePublisher">
-        <param name="period">0.020</param>
+        <param name="period">0.02</param>
         <param name="baseTFName">/Human/Pelvis</param>
         <param name="humanJointsTopic">/Human/joint_states</param>
         <action phase="startup" level="5" type="attach">

--- a/conf/xml/HumanStateProvider.xml
+++ b/conf/xml/HumanStateProvider.xml
@@ -18,7 +18,7 @@
 
     <device type="human_state_provider" name="HumanStateProvider">
         <param name="period">0.100</param>
-        <param name="urdf">Claudia48DoF_Dec2017.urdf</param>
+        <param name="urdf">humanSubject01_66dof.urdf</param>
         <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">pairwised</param>

--- a/conf/xml/HumanStateProvider_second.xml
+++ b/conf/xml/HumanStateProvider_second.xml
@@ -1,27 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<robot name="Human-HDE" build=0 portprefix="">
+<robot name="Human2-HDE" build=0 portprefix="">
 
-    <device type="transformServer" name="TransformServer">
-        <param name="transforms_lifetime">0.2</param>
-        <group name="ROS">
-            <param name="enable_ros_publisher">true</param>
-            <param name="enable_ros_subscriber">false</param>
-        </group>
-    </device>
-
-    <device type="iwear_remapper" name="XSenseIWearRemapper">
-        <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
+    <device type="iwear_remapper" name="XSenseIWearRemapper_2">
+        <param name="wearableDataPorts">(/XSensSuit_2/WearableData/data:o)</param>
         <param name="useRPC">false</param>
-        <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param>
+        <param name="wearableRPCPorts">(/XSensSuit_2/WearableData/metadataRpc:o)</param>
+        <param name="outputPortName">/HDE_2/XsensIWearRemapper/data:o</param>
     </device>
 
-    <device type="human_state_provider" name="HumanStateProvider">
-        <param name="period">0.100</param>
-        <param name="urdf">Claudia48DoF_Dec2017.urdf</param>
+    <device type="human_state_provider" name="HumanStateProvider_2">
+        <param name="period">0.05</param>
+        <param name="urdf">humanSubject01_66dof.urdf</param>
         <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
-        <!-- ikSolver options: pairwised, global, integrationbased -->
-        <param name="ikSolver">pairwised</param>
+        <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>
         <param name="allowIKFailures">true</param>
         <param name="useDirectBaseMeasurement">false</param>
@@ -36,10 +27,11 @@
         <!-- inverse velocity kinematics parameters -->
         <param name="linVelTargetWeight">0.0</param>
         <param name="angVelTargetWeight">1.0</param>
+        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(1.0 1.0)</param>
         <!-- integration based IK parameters -->
-        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(0.1 0.1)</param>
-        <param name="integrationBasedIKCorrectionGainsLinRot">(8.0 8.0)</param>
+        <param name="integrationBasedIKCorrectionGainsLinRot">(5.0 5.0)</param>
         <param name="integrationBasedIKIntegralCorrectionGainsLinRot">(0.0 0.0)</param>
+        <!-- TODO: How to use a reduced model in the entire HDE? (Starting from HumanStateProvider) -->
         <group name="MODEL_TO_DATA_LINK_NAMES">
             <param name="map_Pelvis">(Pelvis, XsensSuit::vLink::Pelvis)</param>
             <param name="map_L5">(L5, XsensSuit::vLink::L5)</param>
@@ -141,13 +133,13 @@
         </group>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
-                <elem name="HumanStateProviderLabel">XSenseIWearRemapper</elem>
+                <elem name="HumanStateProviderLabel">XSenseIWearRemapper_2</elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <device type="human_state_wrapper" name="HumanStateWrapper">
+    <!--device type="human_state_wrapper" name="HumanStateWrapper">
         <param name="period">0.1</param>
         <param name="outputPort">/HDE/HumanStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
@@ -156,18 +148,19 @@
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device>
+    </device-->
 
-    <device type="human_state_publisher" name="HumanStatePublisher">
+    <device type="human_state_publisher" name="HumanStatePublisher_2">
         <param name="period">0.020</param>
-        <param name="baseTFName">/Human/Pelvis</param>
-        <param name="humanJointsTopic">/Human/joint_states</param>
+        <param name="baseTFName">/Human_2/Pelvis</param>
+        <param name="humanJointsTopic">/Human_2/joint_states</param>
+        <param name="portprefix">second</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
-                <elem name="HumanStatePublisherLabel">HumanStateProvider</elem>
+                <elem name="HumanStatePublisherLabel">HumanStateProvider_2</elem>
             </paramlist>
         </action>
-        <action phase="shutdown" level="5" type="detach"/>
+        <action phase="shutdown" level="4" type="detach"/>
     </device>
 
 </robot>

--- a/conf/xml/RobotStateProvider.xml
+++ b/conf/xml/RobotStateProvider.xml
@@ -76,17 +76,17 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <!--device type="human_state_publisher" name="RobotStatePublisher">
-        <param name="period">0.010</param>
+    <device type="human_state_publisher" name="RobotStatePublisher">
+        <param name="period">0.020</param>
         <param name="baseTFName">/Robot/root_link_fake</param>
-        <param name="humanJointsTopic">/icubSim/joint_states</param>
+        <param name="humanJointsTopic">/Robot/joint_states</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStatePublisherLabel">RobotStateProvider</elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device-->
+    </device>
 
     <!-- uncomment if you want to use the RobotStateProvider data to control the robot position -->
     <!--device type="robot_position_controller" name="RobotPositionController">

--- a/conf/xml/RobotStateProvider.xml
+++ b/conf/xml/RobotStateProvider.xml
@@ -17,11 +17,11 @@
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">
-        <param name="period">0.100</param>
+        <param name="period">0.0100</param>
         <param name="urdf">teleoperation_iCub_model_V_2_5.urdf</param>
         <param name="floatingBaseFrame">(root_link_fake, XsensSuit::vLink::Pelvis)</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
-        <param name="ikSolver">pairwised</param>
+        <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>
         <param name="allowIKFailures">true</param>
         <param name="useDirectBaseMeasurement">false</param>
@@ -37,7 +37,7 @@
         <param name="linVelTargetWeight">0.0</param>
         <param name="angVelTargetWeight">1.0</param>
         <!-- integration based IK parameters -->
-        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(0.1 0.1)</param>
+        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(1.0 1.0)</param>
         <param name="integrationBasedIKCorrectionGainsLinRot">(2.0 2.0)</param>
         <param name="integrationBasedIKIntegralCorrectionGainsLinRot">(0.0 0.0)</param>
         <group name="MODEL_TO_DATA_LINK_NAMES">
@@ -76,8 +76,8 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <device type="human_state_publisher" name="RobotStatePublisher">
-        <param name="period">0.020</param>
+    <!--device type="human_state_publisher" name="RobotStatePublisher">
+        <param name="period">0.010</param>
         <param name="baseTFName">/Robot/root_link_fake</param>
         <param name="humanJointsTopic">/Robot/joint_states</param>
         <action phase="startup" level="5" type="attach">
@@ -86,17 +86,17 @@
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device>
+    </device-->
 
     <!-- uncomment if you want to use the RobotStateProvider data to control the robot position -->
     <!--device type="robot_position_controller" name="RobotPositionController">
         <param name="period">0.100</param>
         <param name="controlMode">positionDirect</param>
         <param name="refSpeed">15.0</param>
-        <param name="samplingTime">0.05</param>
-        <param name="smoothingTime">1.0</param>
+        <param name="samplingTime">0.01</param>
+        <param name="smoothingTime">0.25</param>
         <param name="controlBoardsList">(head torso left_arm right_arm left_leg right_leg)</param>
-        <param name="remotePrefix">/icubSim</param>
+        <param name="remotePrefix">/icub</param>
         <param name="localPrefix">/robotPositionController</param>
         <param name="head">(neck_pitch neck_roll neck_yaw)</param>
         <param name="torso">(torso_yaw torso_roll torso_pitch)</param>

--- a/conf/xml/RobotStateProvider.xml
+++ b/conf/xml/RobotStateProvider.xml
@@ -31,7 +31,7 @@
         <param name="ikPoolSizeOption">2</param>
         <param name="posTargetWeight">0.0</param>
         <param name="rotTargetWeight">1.0</param>
-        <param name="costRegularization">0.001</param>
+        <param name="costRegularization">3.0</param>
         <param name="costTolerance">0.001</param>
         <!-- inverse velocity kinematics parameters -->
         <param name="linVelTargetWeight">0.0</param>
@@ -79,7 +79,7 @@
     <!--device type="human_state_publisher" name="RobotStatePublisher">
         <param name="period">0.010</param>
         <param name="baseTFName">/Robot/root_link_fake</param>
-        <param name="humanJointsTopic">/Robot/joint_states</param>
+        <param name="humanJointsTopic">/icubSim/joint_states</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStatePublisherLabel">RobotStateProvider</elem>

--- a/conf/xml/RobotStateProvider.xml
+++ b/conf/xml/RobotStateProvider.xml
@@ -31,7 +31,7 @@
         <param name="ikPoolSizeOption">2</param>
         <param name="posTargetWeight">0.0</param>
         <param name="rotTargetWeight">1.0</param>
-        <param name="costRegularization">3.0</param>
+        <param name="costRegularization">1.0</param>
         <param name="costTolerance">0.001</param>
         <!-- inverse velocity kinematics parameters -->
         <param name="linVelTargetWeight">0.0</param>

--- a/conf/xml/WholeBodyRetargeting.xml
+++ b/conf/xml/WholeBodyRetargeting.xml
@@ -99,8 +99,7 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <!-- uncomment if you want to use the RobotStateProvider data to control the robot position -->
-    <!--device type="robot_position_controller" name="RobotPositionController">
+    <device type="robot_position_controller" name="RobotPositionController">
         <param name="period">0.100</param>
         <param name="controlMode">positionDirect</param>
         <param name="refSpeed">15.0</param>
@@ -121,6 +120,6 @@
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device-->
+    </device>
 
 </robot>

--- a/conf/xml/hands-pHRI.xml
+++ b/conf/xml/hands-pHRI.xml
@@ -190,7 +190,7 @@
 
     <device type="human_wrench_provider" name="HumanWrenchProvider">
         <param name="period">0.100</param>
-        <param name="human_urdf">humanSubject03_66dof.urdf</param>
+        <param name="human_urdf">humanSubject01_66dof.urdf</param>
         <param name="pHRIScenario">true</param>
         <param name="robot_urdf">model.urdf</param>
         <param name="number_of_source_devices">3</param>
@@ -276,7 +276,7 @@
 
     <!--device type="human_dynamics_estimator" name="HumanDynamicsEstimator">
         <param name="period">0.100</param>
-        <param name="urdf">humanSubject03_66dof.urdf</param>
+        <param name="urdf">humanSubject01_66dof.urdf</param>
         <param name="baseLink">Pelvis</param>
         <param name="number_of_wrench_sensors">2</param>
         <param name="wrench_sensors_link_name">(RightHand LeftHand)</param>

--- a/conf/xml/hands-pHRI.xml
+++ b/conf/xml/hands-pHRI.xml
@@ -17,20 +17,39 @@
     </device>
 
     <device type="human_state_provider" name="HumanStateProvider">
-        <param name="period">0.100</param>
-        <param name="urdf">humanSubject03_66dof.urdf</param>
+        <param name="period">0.02</param>
+        <param name="urdf">humanSubject01_66dof.urdf</param>
         <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
+        <!-- ikSolver options: pairwised, global, integrationbased -->
+        <param name="ikSolver">integrationbased</param>
+        <param name="useXsensJointsAngles">false</param>
         <param name="allowIKFailures">true</param>
+        <param name="useDirectBaseMeasurement">false</param>
+        <!-- optimization parameters -->
         <param name="maxIterationsIK">300</param>
         <param name="ikLinearSolver">ma27</param>
-        <param name="ikPoolSizeOption">4</param>
-        <param name="posTargetWeight">0</param>
-        <param name="rotTargetWeight">10</param>
-        <param name="costRegularization">0.25</param>
-        <param name="costTolerance">1E-2</param>
-        <param name="useGlobalIK">false</param>
-        <param name="useXsensJointsAngles">false</param>
-        <!-- TODO: How to use a reduced model in the entire HDE? (Starting from HumanStateProvider) -->
+        <param name="ikPoolSizeOption">2</param>
+        <param name="posTargetWeight">0.0</param>
+        <param name="rotTargetWeight">1.0</param>
+        <param name="costRegularization">0.000001</param>
+        <param name="costTolerance">0.001</param>
+        <!-- inverse velocity kinematics parameters -->
+        <!-- inverseVelocityKinematicsSolver values:
+        moorePenrose,
+        completeOrthogonalDecomposition,
+        leastSquare,
+        choleskyDecomposition,
+        sparseCholeskyDecomposition,
+        robustCholeskyDecomposition,
+        sparseRobustCholeskyDecomposition -->
+        <param name='inverseVelocityKinematicsSolver'>sparseRobustCholeskyDecomposition</param>
+        <param name="linVelTargetWeight">0.0</param>
+        <param name="angVelTargetWeight">1.0</param>
+        <!-- integration based IK parameters -->
+        <param name='integrationBasedJointVelocityLimit'>10.0</param> <!-- comment or -1.0 for no limits -->
+        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(1.0 1.0)</param>
+        <param name="integrationBasedIKCorrectionGainsLinRot">(8.0 20.0)</param>
+        <param name="integrationBasedIKIntegralCorrectionGainsLinRot">(0.0 0.0)</param>
         <group name="MODEL_TO_DATA_LINK_NAMES">
             <param name="map_Pelvis">(Pelvis, XsensSuit::vLink::Pelvis)</param>
             <param name="map_L5">(L5, XsensSuit::vLink::L5)</param>
@@ -138,8 +157,9 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <device type="human_state_wrapper" name="HumanStateWrapper">
-        <param name="period">0.5</param>
+    <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
+    <!-- <device type="human_state_wrapper" name="HumanStateWrapper">
+        <param name="period">0.02</param>
         <param name="outputPort">/HDE/HumanStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
@@ -147,10 +167,10 @@
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device>
+    </device> -->
 
     <device type="human_state_publisher" name="HumanStatePublisher">
-        <param name="period">0.020</param>
+        <param name="period">0.02</param>
         <param name="baseTFName">/Human/Pelvis</param>
         <param name="humanJointsTopic">/Human/joint_states</param>
         <action phase="startup" level="5" type="attach">

--- a/conf/xml/pHRI.xml
+++ b/conf/xml/pHRI.xml
@@ -18,11 +18,11 @@
     </device>
 
     <device type="human_state_provider" name="HumanStateProvider">
-        <param name="period">0.100</param>
+        <param name="period">0.02</param>
         <param name="urdf">humanSubject01_66dof.urdf</param>
         <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
-        <param name="ikSolver">pairwised</param>
+        <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>
         <param name="allowIKFailures">true</param>
         <param name="useDirectBaseMeasurement">false</param>
@@ -35,11 +35,21 @@
         <param name="costRegularization">0.000001</param>
         <param name="costTolerance">0.001</param>
         <!-- inverse velocity kinematics parameters -->
+        <!-- inverseVelocityKinematicsSolver values:
+        moorePenrose,
+        completeOrthogonalDecomposition,
+        leastSquare,
+        choleskyDecomposition,
+        sparseCholeskyDecomposition,
+        robustCholeskyDecomposition,
+        sparseRobustCholeskyDecomposition -->
+        <param name='inverseVelocityKinematicsSolver'>sparseRobustCholeskyDecomposition</param>
         <param name="linVelTargetWeight">0.0</param>
         <param name="angVelTargetWeight">1.0</param>
         <!-- integration based IK parameters -->
-        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(0.1 0.1)</param>
-        <param name="integrationBasedIKCorrectionGainsLinRot">(8.0 8.0)</param>
+        <param name='integrationBasedJointVelocityLimit'>10.0</param> <!-- comment or -1.0 for no limits -->
+        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(1.0 1.0)</param>
+        <param name="integrationBasedIKCorrectionGainsLinRot">(8.0 20.0)</param>
         <param name="integrationBasedIKIntegralCorrectionGainsLinRot">(0.0 0.0)</param>
         <group name="MODEL_TO_DATA_LINK_NAMES">
             <param name="map_Pelvis">(Pelvis, XsensSuit::vLink::Pelvis)</param>
@@ -148,8 +158,9 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <!--device type="human_state_wrapper" name="HumanStateWrapper">
-        <param name="period">0.5</param>
+    <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
+    <!-- <device type="human_state_wrapper" name="HumanStateWrapper">
+        <param name="period">0.02</param>
         <param name="outputPort">/HDE/HumanStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
@@ -157,10 +168,10 @@
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device-->
+    </device> -->
 
     <device type="human_state_publisher" name="HumanStatePublisher">
-        <param name="period">0.020</param>
+        <param name="period">0.02</param>
         <param name="baseTFName">/Human/Pelvis</param>
         <param name="humanJointsTopic">/Human/joint_states</param>
         <action phase="startup" level="5" type="attach">
@@ -168,7 +179,7 @@
                 <elem name="HumanStatePublisherLabel">HumanStateProvider</elem>
             </paramlist>
         </action>
-        <action phase="shutdown" level="4" type="detach"/>
+        <action phase="shutdown" level="5" type="detach"/>
     </device>
 
     <device type="iwear_remapper" name="FTSourcesIWearRemapper">

--- a/conf/xml/pHRI.xml
+++ b/conf/xml/pHRI.xml
@@ -191,7 +191,7 @@
 
     <device type="human_wrench_provider" name="HumanWrenchProvider">
         <param name="period">0.100</param>
-        <param name="human_urdf">humanSubject03_66dof.urdf</param>
+        <param name="human_urdf">humanSubject01_66dof.urdf</param>
         <param name="pHRIScenario">true</param>
         <param name="robot_urdf">model.urdf</param>
         <param name="number_of_source_devices">3</param>
@@ -295,7 +295,7 @@
 
     <device type="human_dynamics_estimator" name="HumanDynamicsEstimator">
         <param name="period">0.100</param>
-        <param name="urdf">humanSubject03_66dof.urdf</param>
+        <param name="urdf">humanSubject01_66dof.urdf</param>
         <param name="baseLink">Pelvis</param>
         <param name="number_of_wrench_sensors">4</param>
         <param name="wrench_sensors_link_name">(LeftFoot RightFoot RightHand LeftHand)</param>

--- a/devices/CMakeLists.txt
+++ b/devices/CMakeLists.txt
@@ -5,7 +5,7 @@
 add_subdirectory(HumanStateProvider)
 add_subdirectory(HumanWrenchProvider)
 add_subdirectory(HumanDynamicsEstimator)
-#add_subdirectory(HumanControlBoard)
+add_subdirectory(HumanControlBoard)
 add_subdirectory(XsensHumanStateProvider)
 add_subdirectory(RobotPositionController)
 add_subdirectory(Utilities)

--- a/devices/HumanControlBoard/conf/human_control_board.ini
+++ b/devices/HumanControlBoard/conf/human_control_board.ini
@@ -1,0 +1,5 @@
+[plugin human_control_board]
+type device
+name human_control_board
+wrapper controlboardwrapper2
+library HumanControlBoard

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -245,8 +245,7 @@ HumanStateProvider::HumanStateProvider()
     , pImpl{new impl()}
 {}
 
-HumanStateProvider::~HumanStateProvider()
-{}
+HumanStateProvider::~HumanStateProvider() {}
 
 bool HumanStateProvider::open(yarp::os::Searchable& config)
 {
@@ -312,8 +311,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         pImpl->ikSolver = SolverIK::pairwised;
     else if (solverName == "integrationbased")
         pImpl->ikSolver = SolverIK::integrationbased;
-    else
-    {
+    else {
         yError() << LogPrefix << "ikSolver " << solverName << " not found";
         return false;
     }
@@ -377,8 +375,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         }
     }
 
-    if (pImpl->ikSolver == SolverIK::pairwised || pImpl->ikSolver == SolverIK::global)
-    {
+    if (pImpl->ikSolver == SolverIK::pairwised || pImpl->ikSolver == SolverIK::global) {
         if (!(config.check("allowIKFailures") && config.find("allowIKFailures").isBool())) {
             yError() << LogPrefix << "allowFailures option not found or not valid";
             return false;
@@ -419,9 +416,9 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         pImpl->costRegularization = config.find("costRegularization").asDouble();
     }
 
-    if (pImpl->ikSolver == SolverIK::global || pImpl->ikSolver == SolverIK::integrationbased)
-    {
-        if (!(config.check("useDirectBaseMeasurement") && config.find("useDirectBaseMeasurement").isBool())) {
+    if (pImpl->ikSolver == SolverIK::global || pImpl->ikSolver == SolverIK::integrationbased) {
+        if (!(config.check("useDirectBaseMeasurement")
+              && config.find("useDirectBaseMeasurement").isBool())) {
             yError() << LogPrefix << "useDirectBaseMeasurement option not found or not valid";
             return false;
         }
@@ -442,9 +439,10 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         pImpl->angVelTargetWeight = config.find("angVelTargetWeight").asFloat64();
     }
 
-    if (pImpl->ikSolver == SolverIK::pairwised)
-    {
-        if (!(config.check("ikPoolSizeOption") && (config.find("ikPoolSizeOption").isString() || config.find("ikPoolSizeOption").isInt()))) {
+    if (pImpl->ikSolver == SolverIK::pairwised) {
+        if (!(config.check("ikPoolSizeOption")
+              && (config.find("ikPoolSizeOption").isString()
+                  || config.find("ikPoolSizeOption").isInt()))) {
             yError() << LogPrefix << "ikPoolOption option not found or not valid";
             return false;
         }
@@ -471,16 +469,19 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         pImpl->useDirectBaseMeasurement = true;
     }
 
-    if (pImpl->ikSolver == SolverIK::integrationbased)
-    {
-        if (!(config.check("integrationBasedIKMeasuredVelocityGainLinRot") && config.find("integrationBasedIKMeasuredVelocityGainLinRot").isList()
-              && config.find("integrationBasedIKMeasuredVelocityGainLinRot").asList()->size() == 2)) {
-            yError() << LogPrefix
-                     << "integrationBasedIKMeasuredVelocityGainLinRot option not found or not valid";
+    if (pImpl->ikSolver == SolverIK::integrationbased) {
+        if (!(config.check("integrationBasedIKMeasuredVelocityGainLinRot")
+              && config.find("integrationBasedIKMeasuredVelocityGainLinRot").isList()
+              && config.find("integrationBasedIKMeasuredVelocityGainLinRot").asList()->size()
+                     == 2)) {
+            yError()
+                << LogPrefix
+                << "integrationBasedIKMeasuredVelocityGainLinRot option not found or not valid";
             return false;
         }
 
-        if (!(config.check("integrationBasedIKCorrectionGainsLinRot") && config.find("integrationBasedIKCorrectionGainsLinRot").isList()
+        if (!(config.check("integrationBasedIKCorrectionGainsLinRot")
+              && config.find("integrationBasedIKCorrectionGainsLinRot").isList()
               && config.find("integrationBasedIKCorrectionGainsLinRot").asList()->size() == 2)) {
             yError() << LogPrefix
                      << "integrationBasedIKCorrectionGainsLinRot option not found or not valid";
@@ -526,9 +527,9 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
     yInfo() << LogPrefix << "*** Urdf file name                   :" << urdfFileName;
     yInfo() << LogPrefix << "*** Ik solver                        :" << solverName;
     yInfo() << LogPrefix << "*** Use Xsens joint angles           :" << pImpl->useXsensJointsAngles;
-    yInfo() << LogPrefix << "*** Use Directly base measurement    :" << pImpl->useDirectBaseMeasurement;
-    if (pImpl->ikSolver == SolverIK::pairwised || pImpl->ikSolver == SolverIK::global)
-    {
+    yInfo() << LogPrefix
+            << "*** Use Directly base measurement    :" << pImpl->useDirectBaseMeasurement;
+    if (pImpl->ikSolver == SolverIK::pairwised || pImpl->ikSolver == SolverIK::global) {
         yInfo() << LogPrefix << "*** Allow IK failures                :" << pImpl->allowIKFailures;
         yInfo() << LogPrefix << "*** Max IK iterations                :" << pImpl->maxIterationsIK;
         yInfo() << LogPrefix << "*** Cost Tolerance                   :" << pImpl->costTolerance;
@@ -539,14 +540,19 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
                 << "*** Cost regularization              :" << pImpl->costRegularization;
         yInfo() << LogPrefix << "*** Size of thread pool              :" << pImpl->ikPoolSize;
     }
-    if (pImpl->ikSolver == SolverIK::integrationbased)
-    {
-        yInfo() << LogPrefix << "*** Measured Linear velocity gain    :" << pImpl->integrationBasedIKMeasuredLinearVelocityGain;
-        yInfo() << LogPrefix << "*** Measured Angular velocity gain   :" << pImpl->integrationBasedIKMeasuredAngularVelocityGain;
-        yInfo() << LogPrefix << "*** Linear correction gain           :" << pImpl->integrationBasedIKLinearCorrectionGain;
-        yInfo() << LogPrefix << "*** Angular correction gain          :" << pImpl->integrationBasedIKAngularCorrectionGain;
-        yInfo() << LogPrefix << "*** Linear integral correction gain  :" << pImpl->integrationBasedIKIntegralLinearCorrectionGain;
-        yInfo() << LogPrefix << "*** Angular integral correction gain :" << pImpl->integrationBasedIKIntegralAngularCorrectionGain;
+    if (pImpl->ikSolver == SolverIK::integrationbased) {
+        yInfo() << LogPrefix << "*** Measured Linear velocity gain    :"
+                << pImpl->integrationBasedIKMeasuredLinearVelocityGain;
+        yInfo() << LogPrefix << "*** Measured Angular velocity gain   :"
+                << pImpl->integrationBasedIKMeasuredAngularVelocityGain;
+        yInfo() << LogPrefix << "*** Linear correction gain           :"
+                << pImpl->integrationBasedIKLinearCorrectionGain;
+        yInfo() << LogPrefix << "*** Angular correction gain          :"
+                << pImpl->integrationBasedIKAngularCorrectionGain;
+        yInfo() << LogPrefix << "*** Linear integral correction gain  :"
+                << pImpl->integrationBasedIKIntegralLinearCorrectionGain;
+        yInfo() << LogPrefix << "*** Angular integral correction gain :"
+                << pImpl->integrationBasedIKIntegralAngularCorrectionGain;
     }
     yInfo() << LogPrefix << "*** ==================================";
 
@@ -680,15 +686,12 @@ void HumanStateProvider::run()
     }
 
     // check if inverse kinematics failed
-    if (inverseKinematicsFailure)
-    {
-        if (pImpl->allowIKFailures)
-        {
+    if (inverseKinematicsFailure) {
+        if (pImpl->allowIKFailures) {
             yWarning() << LogPrefix << "IK failed, keeping the previous solution";
             return;
         }
-        else
-        {
+        else {
             yError() << LogPrefix << "Failed to solve IK";
             askToStop();
         }
@@ -734,7 +737,8 @@ void HumanStateProvider::run()
                                         pImpl->baseVelocitySolution.getVal(5)};
     }
 
-    // compute the inverse kinematic errors (currently the result is unused, but it may be used for evaluating the IK performance)
+    // compute the inverse kinematic errors (currently the result is unused, but it may be used for
+    // evaluating the IK performance)
     // pImpl->computeLinksOrientationErrors(pImpl->linkTransformMatrices,
     //                                      pImpl->jointConfigurationSolution,
     //                                      pImpl->baseTransformSolution,
@@ -917,7 +921,7 @@ bool HumanStateProvider::impl::initializePairwisedInverseKinematicsSolver()
         std::string modelLinkName = humanModel.getLinkName(linkIndex);
 
         if (wearableStorage.modelToWearable_LinkName.find(modelLinkName)
-                == wearableStorage.modelToWearable_LinkName.end()) {
+            == wearableStorage.modelToWearable_LinkName.end()) {
             continue;
         }
 
@@ -925,13 +929,13 @@ bool HumanStateProvider::impl::initializePairwisedInverseKinematicsSolver()
         // segments[segmentIndex].velocities.zero();
 
         // Store the name of the link as segment name
-        segments[segmentIndex].segmentName =  modelLinkName;
+        segments[segmentIndex].segmentName = modelLinkName;
         segmentIndex++;
     }
 
     // Get all the possible pairs composing the model
     std::vector<std::pair<std::string, std::string>> pairNames;
-    std::vector<std::pair<iDynTree::FrameIndex, iDynTree::FrameIndex> > pairSegmentIndeces;
+    std::vector<std::pair<iDynTree::FrameIndex, iDynTree::FrameIndex>> pairSegmentIndeces;
 
     // Get the link pair names
     createEndEffectorsPairs(humanModel, segments, pairNames, pairSegmentIndeces);
@@ -947,10 +951,14 @@ bool HumanStateProvider::impl::initializePairwisedInverseKinematicsSolver()
         pairInfo.childFrameSegmentsIndex = pairSegmentIndeces[index].second;
 
         // Get the reduced pair model
-        if (!getReducedModel(humanModel, pairInfo.parentFrameName, pairInfo.childFrameName, pairInfo.pairModel)) {
+        if (!getReducedModel(humanModel,
+                             pairInfo.parentFrameName,
+                             pairInfo.childFrameName,
+                             pairInfo.pairModel)) {
 
-            yWarning() << LogPrefix << "failed to get reduced model for the segment pair " << pairInfo.parentFrameName.c_str()
-                       << ", " << pairInfo.childFrameName.c_str();
+            yWarning() << LogPrefix << "failed to get reduced model for the segment pair "
+                       << pairInfo.parentFrameName.c_str() << ", "
+                       << pairInfo.childFrameName.c_str();
             continue;
         }
 
@@ -962,18 +970,22 @@ bool HumanStateProvider::impl::initializePairwisedInverseKinematicsSolver()
         pairInfo.ikSolver->setLinearSolverName(linearSolverName);
         pairInfo.ikSolver->setMaxIterations(maxIterationsIK);
         pairInfo.ikSolver->setCostTolerance(costTolerance);
-        pairInfo.ikSolver->setDefaultTargetResolutionMode(iDynTree::InverseKinematicsTreatTargetAsConstraintNone);
-        pairInfo.ikSolver->setRotationParametrization(iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw);
+        pairInfo.ikSolver->setDefaultTargetResolutionMode(
+            iDynTree::InverseKinematicsTreatTargetAsConstraintNone);
+        pairInfo.ikSolver->setRotationParametrization(
+            iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw);
 
         // Set ik model
         if (!pairInfo.ikSolver->setModel(pairInfo.pairModel)) {
-            yWarning() << LogPrefix << "failed to configure IK solver for the segment pair" << pairInfo.parentFrameName.c_str()
-                       << ", " << pairInfo.childFrameName.c_str() <<  " Skipping pair";
+            yWarning() << LogPrefix << "failed to configure IK solver for the segment pair"
+                       << pairInfo.parentFrameName.c_str() << ", "
+                       << pairInfo.childFrameName.c_str() << " Skipping pair";
             continue;
         }
 
         // Add parent link as fixed base constraint with identity transform
-        pairInfo.ikSolver->addFrameConstraint(pairInfo.parentFrameName, iDynTree::Transform::Identity());
+        pairInfo.ikSolver->addFrameConstraint(pairInfo.parentFrameName,
+                                              iDynTree::Transform::Identity());
 
         // Add child link as a target and set initial transform to be identity
         pairInfo.ikSolver->addTarget(pairInfo.childFrameName, iDynTree::Transform::Identity());
@@ -986,12 +998,15 @@ bool HumanStateProvider::impl::initializePairwisedInverseKinematicsSolver()
         pairInfo.costRegularization = costRegularization;
 
         // Get floating base for the pair model
-        pairInfo.floatingBaseIndex = pairInfo.pairModel.getFrameLink(pairInfo.pairModel.getFrameIndex(pairInfo.parentFrameName));
+        pairInfo.floatingBaseIndex = pairInfo.pairModel.getFrameLink(
+            pairInfo.pairModel.getFrameIndex(pairInfo.parentFrameName));
 
         // Set ik floating base
-        if (!pairInfo.ikSolver->setFloatingBaseOnFrameNamed(pairInfo.pairModel.getLinkName(pairInfo.floatingBaseIndex))) {
-            yError() << "Failed to set floating base frame for the segment pair" << pairInfo.parentFrameName.c_str()
-                     << ", " << pairInfo.childFrameName.c_str() <<  " Skipping pair";
+        if (!pairInfo.ikSolver->setFloatingBaseOnFrameNamed(
+                pairInfo.pairModel.getLinkName(pairInfo.floatingBaseIndex))) {
+            yError() << "Failed to set floating base frame for the segment pair"
+                     << pairInfo.parentFrameName.c_str() << ", " << pairInfo.childFrameName.c_str()
+                     << " Skipping pair";
             return false;
         }
 
@@ -1005,21 +1020,23 @@ bool HumanStateProvider::impl::initializePairwisedInverseKinematicsSolver()
         // Resize to number of joints in the pair model
         solverJoints.resize(pairInfo.pairModel.getNrOfJoints());
 
-        for (int i=0; i < pairInfo.pairModel.getNrOfJoints(); i++) {
+        for (int i = 0; i < pairInfo.pairModel.getNrOfJoints(); i++) {
             solverJoints[i] = pairInfo.pairModel.getJointName(i);
         }
 
         pairInfo.consideredJointLocations.reserve(solverJoints.size());
-        for (auto &jointName: solverJoints) {
+        for (auto& jointName : solverJoints) {
             iDynTree::JointIndex jointIndex = humanModel.getJointIndex(jointName);
             if (jointIndex == iDynTree::JOINT_INVALID_INDEX) {
-                yWarning() << LogPrefix << "IK considered joint " << jointName << " not found in the complete model";
+                yWarning() << LogPrefix << "IK considered joint " << jointName
+                           << " not found in the complete model";
                 continue;
             }
             iDynTree::IJointConstPtr joint = humanModel.getJoint(jointIndex);
 
             // Save location index and length of each DoFs
-            pairInfo.consideredJointLocations.push_back(std::pair<size_t, size_t>(joint->getDOFsOffset(), joint->getNrOfDOFs()));
+            pairInfo.consideredJointLocations.push_back(
+                std::pair<size_t, size_t>(joint->getDOFsOffset(), joint->getNrOfDOFs()));
         }
 
         // Set the joint configurations size and initialize to zero
@@ -1036,7 +1053,8 @@ bool HumanStateProvider::impl::initializePairwisedInverseKinematicsSolver()
         pairInfo.childFrameModelIndex = pairInfo.pairModel.getFrameIndex(pairInfo.childFrameName);
 
         // Configure KinDynComputation
-        pairInfo.kinDynComputations = std::unique_ptr<iDynTree::KinDynComputations>(new iDynTree::KinDynComputations());
+        pairInfo.kinDynComputations =
+            std::unique_ptr<iDynTree::KinDynComputations>(new iDynTree::KinDynComputations());
         pairInfo.kinDynComputations->loadRobotModel(pairInfo.pairModel);
 
         // Configure relative Jacobian
@@ -1048,9 +1066,7 @@ bool HumanStateProvider::impl::initializePairwisedInverseKinematicsSolver()
     }
 
     // Initialize IK Worker Pool
-    ikPool = std::unique_ptr<IKWorkerPool>(new IKWorkerPool(ikPoolSize,
-                                                                             linkPairs,
-                                                                             segments));
+    ikPool = std::unique_ptr<IKWorkerPool>(new IKWorkerPool(ikPoolSize, linkPairs, segments));
     if (!ikPool) {
         yError() << LogPrefix << "failed to create IK worker pool";
         return false;
@@ -1068,21 +1084,21 @@ bool HumanStateProvider::impl::initializePairwisedInverseKinematicsSolver()
                 linkPair.sInitial.setVal(i, averageJointLimit);
             }
         }
-
     }
 
     return true;
 }
 
 bool HumanStateProvider::impl::initializeGlobalInverseKinematicsSolver()
-{           
+{
     // Set global ik parameters
     globalIK.setVerbosity(1);
     globalIK.setLinearSolverName(linearSolverName);
     globalIK.setMaxIterations(maxIterationsIK);
     globalIK.setCostTolerance(costTolerance);
     globalIK.setDefaultTargetResolutionMode(iDynTree::InverseKinematicsTreatTargetAsConstraintNone);
-    globalIK.setRotationParametrization(iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw);
+    globalIK.setRotationParametrization(
+        iDynTree::InverseKinematicsRotationParametrizationRollPitchYaw);
 
     if (!globalIK.setModel(humanModel)) {
         yError() << LogPrefix << "globalIK: failed to load the model";
@@ -1132,8 +1148,7 @@ bool HumanStateProvider::impl::initializeIntegrationBasedInverseKinematicsSolver
     jointLowerLimits.resize(humanModel.getNrOfDOFs());
     iDynTree::VectorDynSize jointUpperLimits;
     jointUpperLimits.resize(humanModel.getNrOfDOFs());
-    for (int jointIndex=0; jointIndex<humanModel.getNrOfDOFs(); jointIndex++)
-    {
+    for (int jointIndex = 0; jointIndex < humanModel.getNrOfDOFs(); jointIndex++) {
         jointLowerLimits.setVal(jointIndex, humanModel.getJoint(jointIndex)->getMinPosLimit(0));
         jointUpperLimits.setVal(jointIndex, humanModel.getJoint(jointIndex)->getMaxPosLimit(0));
     }
@@ -1187,15 +1202,19 @@ bool HumanStateProvider::impl::solvePairwisedInverseKinematicsSolver()
 
             // Check if it is a valid 1 DoF joint
             if (pairJoint.second == 1) {
-                jointConfigurationSolution.setVal(pairJoint.first, linkPair.jointConfigurations.getVal(jointIndex));
-                jointVelocitiesSolution.setVal(pairJoint.first, linkPair.jointVelocities.getVal(jointIndex));
+                jointConfigurationSolution.setVal(pairJoint.first,
+                                                  linkPair.jointConfigurations.getVal(jointIndex));
+                jointVelocitiesSolution.setVal(pairJoint.first,
+                                               linkPair.jointVelocities.getVal(jointIndex));
 
                 linkPair.sInitial.setVal(jointIndex,
                                          linkPair.jointConfigurations.getVal(jointIndex));
                 jointIndex++;
             }
             else {
-                yWarning() << LogPrefix << " Invalid DoFs for the joint, skipping the ik solution for this joint";
+                yWarning()
+                    << LogPrefix
+                    << " Invalid DoFs for the joint, skipping the ik solution for this joint";
                 continue;
             }
         }
@@ -1207,8 +1226,10 @@ bool HumanStateProvider::impl::solvePairwisedInverseKinematicsSolver()
 bool HumanStateProvider::impl::solveGlobalInverseKinematicsSolver()
 {
     // Set global IK initial condition
-    if (!globalIK.setFullJointsInitialCondition(&baseTransformSolution, &jointConfigurationSolution)) {
-        yError() << LogPrefix << "Failed to set the joint configuration for initializing the global IK";
+    if (!globalIK.setFullJointsInitialCondition(&baseTransformSolution,
+                                                &jointConfigurationSolution)) {
+        yError() << LogPrefix
+                 << "Failed to set the joint configuration for initializing the global IK";
         return false;
     }
 
@@ -1223,13 +1244,13 @@ bool HumanStateProvider::impl::solveGlobalInverseKinematicsSolver()
     posturalTaskJointAngles.resize(jointConfigurationSolution.size());
     posturalTaskJointAngles.zero();
     if (!globalIK.setDesiredFullJointsConfiguration(posturalTaskJointAngles, costRegularization)) {
-         yError() << LogPrefix << "Failed to set the postural configuration of the IK";
-         return false;
-     }
+        yError() << LogPrefix << "Failed to set the postural configuration of the IK";
+        return false;
+    }
 
     if (!globalIK.solve()) {
-            yError() << LogPrefix << "Failed to solve global IK";
-            return false;
+        yError() << LogPrefix << "Failed to solve global IK";
+        return false;
     }
 
     // Get the global inverse kinematics solution
@@ -1237,20 +1258,23 @@ bool HumanStateProvider::impl::solveGlobalInverseKinematicsSolver()
 
     // INVERSE VELOCITY KINEMATICS
     // Set joint configuration
-    if (!inverseVelocityKinematics.setConfiguration(baseTransformSolution, jointConfigurationSolution)) {
-        yError() << LogPrefix << "Failed to set the joint configuration for initializing the inverse velocity kinematics";
+    if (!inverseVelocityKinematics.setConfiguration(baseTransformSolution,
+                                                    jointConfigurationSolution)) {
+        yError() << LogPrefix
+                 << "Failed to set the joint configuration for initializing the inverse velocity "
+                    "kinematics";
         return false;
     }
 
     // Update ivk velocity targets based on wearable input data
-    if(!updateInverseVelocityKinematicTargets()) {
+    if (!updateInverseVelocityKinematicTargets()) {
         yError() << LogPrefix << "Failed to update the targets for the inverse velocity kinematics";
         return false;
     }
 
     if (!inverseVelocityKinematics.solve()) {
-            yError() << LogPrefix << "Failed to solve inverse velocity kinematics";
-            return false;
+        yError() << LogPrefix << "Failed to solve inverse velocity kinematics";
+        return false;
     }
 
     inverseVelocityKinematics.getVelocitySolution(baseVelocitySolution, jointVelocitiesSolution);
@@ -1260,28 +1284,29 @@ bool HumanStateProvider::impl::solveGlobalInverseKinematicsSolver()
 
 bool HumanStateProvider::impl::solveIntegrationBasedInverseKinematics()
 {
-    //compute timestep
+    // compute timestep
     double dt;
-    if (lastTime < 0.0)
-    {
+    if (lastTime < 0.0) {
         dt = period;
     }
-    else
-    {
-        dt = yarp::os::Time::now()-lastTime;
+    else {
+        dt = yarp::os::Time::now() - lastTime;
     };
     lastTime = yarp::os::Time::now();
 
     // LINK VELOCITY CORRECTION
-    iDynTree::KinDynComputations *computations = kinDynComputations.get();
+    iDynTree::KinDynComputations* computations = kinDynComputations.get();
 
-    if (useDirectBaseMeasurement)
-    {
-        computations->setRobotState(jointConfigurationSolution, jointVelocitiesSolution, worldGravity);
+    if (useDirectBaseMeasurement) {
+        computations->setRobotState(
+            jointConfigurationSolution, jointVelocitiesSolution, worldGravity);
     }
-    else
-    {
-        computations->setRobotState(baseTransformSolution, jointConfigurationSolution, baseVelocitySolution, jointVelocitiesSolution, worldGravity);
+    else {
+        computations->setRobotState(baseTransformSolution,
+                                    jointConfigurationSolution,
+                                    baseVelocitySolution,
+                                    jointVelocitiesSolution,
+                                    worldGravity);
     }
 
     for (size_t linkIndex = 0; linkIndex < humanModel.getNrOfLinks(); ++linkIndex) {
@@ -1289,67 +1314,105 @@ bool HumanStateProvider::impl::solveIntegrationBasedInverseKinematics()
 
         // skip fake links
         if (wearableStorage.modelToWearable_LinkName.find(linkName)
-                == wearableStorage.modelToWearable_LinkName.end()) {
+            == wearableStorage.modelToWearable_LinkName.end()) {
             continue;
         }
 
-        iDynTree::Rotation rotationError = computations->getWorldTransform(humanModel.getFrameIndex(linkName)).getRotation() * linkTransformMatrices[linkName].getRotation().inverse();
+        iDynTree::Rotation rotationError =
+            computations->getWorldTransform(humanModel.getFrameIndex(linkName)).getRotation()
+            * linkTransformMatrices[linkName].getRotation().inverse();
         iDynTree::Vector3 angularVelocityError;
 
         angularVelocityError = iDynTreeHelper::Rotation::skewVee(rotationError);
-        iDynTree::toEigen(integralOrientationError) = iDynTree::toEigen(integralOrientationError) +  iDynTree::toEigen(angularVelocityError) * dt;
+        iDynTree::toEigen(integralOrientationError) =
+            iDynTree::toEigen(integralOrientationError)
+            + iDynTree::toEigen(angularVelocityError) * dt;
 
-        // for floating base link use error also on position if not useDirectBaseMeasurement, otherwise skip the link
+        // for floating base link use error also on position if not useDirectBaseMeasurement,
+        // otherwise skip the link
         if (linkName == floatingBaseFrame.model) {
-           if (useDirectBaseMeasurement)
-           {
-               continue;
-           }
+            if (useDirectBaseMeasurement) {
+                continue;
+            }
 
-           iDynTree::Vector3 linearVelocityError;
-           linearVelocityError = computations->getWorldTransform(humanModel.getFrameIndex(linkName)).getPosition() - linkTransformMatrices[linkName].getPosition();
-           iDynTree::toEigen(integralLinearVelocityError) = iDynTree::toEigen(integralLinearVelocityError) +  iDynTree::toEigen(linearVelocityError) * dt;
-           for (int i=0; i<3; i++) {
-               linkVelocities[linkName].setVal(i, integrationBasedIKMeasuredLinearVelocityGain * linkVelocities[linkName].getVal(i) - integrationBasedIKLinearCorrectionGain * linearVelocityError.getVal(i) - integrationBasedIKIntegralLinearCorrectionGain * integralLinearVelocityError.getVal(i));
-           }
+            iDynTree::Vector3 linearVelocityError;
+            linearVelocityError =
+                computations->getWorldTransform(humanModel.getFrameIndex(linkName)).getPosition()
+                - linkTransformMatrices[linkName].getPosition();
+            iDynTree::toEigen(integralLinearVelocityError) =
+                iDynTree::toEigen(integralLinearVelocityError)
+                + iDynTree::toEigen(linearVelocityError) * dt;
+            for (int i = 0; i < 3; i++) {
+                linkVelocities[linkName].setVal(i,
+                                                integrationBasedIKMeasuredLinearVelocityGain
+                                                        * linkVelocities[linkName].getVal(i)
+                                                    - integrationBasedIKLinearCorrectionGain
+                                                          * linearVelocityError.getVal(i)
+                                                    - integrationBasedIKIntegralLinearCorrectionGain
+                                                          * integralLinearVelocityError.getVal(i));
+            }
         }
 
         // correct the links angular velocities
-        for (int i=3; i<6; i++) {
-            linkVelocities[linkName].setVal(i, integrationBasedIKMeasuredAngularVelocityGain * linkVelocities[linkName].getVal(i) -  integrationBasedIKAngularCorrectionGain * angularVelocityError.getVal(i-3) -  integrationBasedIKIntegralAngularCorrectionGain  * integralOrientationError.getVal(i-3));
+        for (int i = 3; i < 6; i++) {
+            linkVelocities[linkName].setVal(
+                i,
+                integrationBasedIKMeasuredAngularVelocityGain * linkVelocities[linkName].getVal(i)
+                    - integrationBasedIKAngularCorrectionGain * angularVelocityError.getVal(i - 3)
+                    - integrationBasedIKIntegralAngularCorrectionGain
+                          * integralOrientationError.getVal(i - 3));
         }
     }
 
     // INVERSE VELOCITY KINEMATICS
     // Set joint configuration
-    if (!inverseVelocityKinematics.setConfiguration(baseTransformSolution, jointConfigurationSolution)) {
-        yError() << LogPrefix << "Failed to set the joint configuration for initializing the global IK";
+    if (!inverseVelocityKinematics.setConfiguration(baseTransformSolution,
+                                                    jointConfigurationSolution)) {
+        yError() << LogPrefix
+                 << "Failed to set the joint configuration for initializing the global IK";
         return false;
     }
 
     // Update ivk velocity targets based on wearable input data
-    if(!updateInverseVelocityKinematicTargets()) {
+    if (!updateInverseVelocityKinematicTargets()) {
         return false;
     }
 
     if (!inverseVelocityKinematics.solve()) {
-            yError() << LogPrefix << "Failed to solve inverse velocity kinematics";
-            return false;
+        yError() << LogPrefix << "Failed to solve inverse velocity kinematics";
+        return false;
     }
 
     inverseVelocityKinematics.getVelocitySolution(baseVelocitySolution, jointVelocitiesSolution);
 
+    double max_velocity_val = 10.0;
+    // Add here the joint velocity limits
+    for (unsigned i = 0; i < jointVelocitiesSolution.size(); i++) {
+        if (jointVelocitiesSolution.getVal(i) > max_velocity_val) {
+            yWarning() << LogPrefix << "joint velocity out of limit: " << humanModel.getJointName(i)
+                       << " : " << jointVelocitiesSolution.getVal(i);
+            jointVelocitiesSolution.setVal(i, max_velocity_val);
+        }
+        else if (jointVelocitiesSolution.getVal(i) < (-1.0 * max_velocity_val)) {
+            yWarning() << LogPrefix << "joint velocity out of limit: " << humanModel.getJointName(i)
+                       << " : " << jointVelocitiesSolution.getVal(i);
+            jointVelocitiesSolution.setVal(i, -1.0 * max_velocity_val);
+        }
+    }
+    yInfo() << "**********************************";
+
     // VELOCITY INTEGRATION
     // integrate velocities measurements
-    if (!useDirectBaseMeasurement)
-    {
-        stateIntegrator.integrate(jointVelocitiesSolution, baseVelocitySolution.getLinearVec3(), baseVelocitySolution.getAngularVec3(), dt);
+    if (!useDirectBaseMeasurement) {
+        stateIntegrator.integrate(jointVelocitiesSolution,
+                                  baseVelocitySolution.getLinearVec3(),
+                                  baseVelocitySolution.getAngularVec3(),
+                                  dt);
 
         stateIntegrator.getJointConfiguration(jointConfigurationSolution);
         stateIntegrator.getBasePose(baseTransformSolution);
     }
-    else
-    {
+    else {
         stateIntegrator.integrate(jointVelocitiesSolution, dt);
 
         stateIntegrator.getJointConfiguration(jointConfigurationSolution);
@@ -1537,7 +1600,9 @@ bool HumanStateProvider::impl::computeLinksOrientationErrors(
 
     for (const auto& linkMapEntry : linkDesiredTransforms) {
         const ModelLinkName& linkName = linkMapEntry.first;
-        linkErrorOrientations[linkName] = iDynTreeHelper::Rotation::rotationDistance(computations->getWorldTransform(linkName).getRotation(), linkDesiredTransforms[linkName].getRotation());
+        linkErrorOrientations[linkName] = iDynTreeHelper::Rotation::rotationDistance(
+            computations->getWorldTransform(linkName).getRotation(),
+            linkDesiredTransforms[linkName].getRotation());
     }
     return true;
 }
@@ -1687,7 +1752,7 @@ bool HumanStateProvider::attach(yarp::dev::PolyDriver* poly)
 
 void HumanStateProvider::threadRelease()
 {
-    if(!pImpl->ikPool->closeIKWorkerPool()) {
+    if (!pImpl->ikPool->closeIKWorkerPool()) {
         yError() << LogPrefix << "Failed to close the IKWorker pool";
     }
 }

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -437,6 +437,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         pImpl->useDirectBaseMeasurement = config.find("useDirectBaseMeasurement").asBool();
         pImpl->linVelTargetWeight = config.find("linVelTargetWeight").asFloat64();
         pImpl->angVelTargetWeight = config.find("angVelTargetWeight").asFloat64();
+        pImpl->costRegularization = config.find("costRegularization").asDouble();
     }
 
     if (pImpl->ikSolver == SolverIK::pairwised) {
@@ -553,6 +554,8 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
                 << pImpl->integrationBasedIKIntegralLinearCorrectionGain;
         yInfo() << LogPrefix << "*** Angular integral correction gain :"
                 << pImpl->integrationBasedIKIntegralAngularCorrectionGain;
+        yInfo() << LogPrefix
+                << "*** Cost regularization              :" << pImpl->costRegularization;
     }
     yInfo() << LogPrefix << "*** ==================================";
 
@@ -1158,6 +1161,8 @@ bool HumanStateProvider::impl::initializeIntegrationBasedInverseKinematicsSolver
 
     // Set global Inverse Velocity Kinematics parameters
     inverseVelocityKinematics.setResolutionMode(InverseVelocityKinematics::pseudoinverse);
+    // Set Regularization Term:
+    inverseVelocityKinematics.setRegularization(costRegularization);
 
     if (!inverseVelocityKinematics.setModel(humanModel)) {
         yError() << LogPrefix << "IBIK: failed to load the model";
@@ -1174,6 +1179,7 @@ bool HumanStateProvider::impl::initializeIntegrationBasedInverseKinematicsSolver
         yError() << LogPrefix << "Failed to set the inverse velocity kinematics targets";
         return false;
     }
+
     return true;
 }
 
@@ -1391,12 +1397,12 @@ bool HumanStateProvider::impl::solveIntegrationBasedInverseKinematics()
         if (jointVelocitiesSolution.getVal(i) > max_velocity_val) {
             yWarning() << LogPrefix << "joint velocity out of limit: " << humanModel.getJointName(i)
                        << " : " << jointVelocitiesSolution.getVal(i);
-            jointVelocitiesSolution.setVal(i, max_velocity_val);
+            //            jointVelocitiesSolution.setVal(i, max_velocity_val);
         }
         else if (jointVelocitiesSolution.getVal(i) < (-1.0 * max_velocity_val)) {
             yWarning() << LogPrefix << "joint velocity out of limit: " << humanModel.getJointName(i)
                        << " : " << jointVelocitiesSolution.getVal(i);
-            jointVelocitiesSolution.setVal(i, -1.0 * max_velocity_val);
+            //            jointVelocitiesSolution.setVal(i, -1.0 * max_velocity_val);
         }
     }
     yInfo() << "**********************************";

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -575,6 +575,13 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         yError() << LogPrefix << "Failed to load model" << urdfFilePath;
         return false;
     }
+    yInfo() << LogPrefix << "----------------------------------------" << modelLoader.isValid();
+    yInfo() << LogPrefix << modelLoader.model().toString();
+    yInfo() << LogPrefix << modelLoader.model().getNrOfLinks()
+            << " , joints: " << modelLoader.model().getNrOfJoints();
+
+    yInfo() << LogPrefix << "base link: "
+            << modelLoader.model().getLinkName(modelLoader.model().getDefaultBaseLink());
 
     // ====================
     // INITIALIZE VARIABLES
@@ -1397,12 +1404,12 @@ bool HumanStateProvider::impl::solveIntegrationBasedInverseKinematics()
         if (jointVelocitiesSolution.getVal(i) > max_velocity_val) {
             yWarning() << LogPrefix << "joint velocity out of limit: " << humanModel.getJointName(i)
                        << " : " << jointVelocitiesSolution.getVal(i);
-            //            jointVelocitiesSolution.setVal(i, max_velocity_val);
+            jointVelocitiesSolution.setVal(i, max_velocity_val);
         }
         else if (jointVelocitiesSolution.getVal(i) < (-1.0 * max_velocity_val)) {
             yWarning() << LogPrefix << "joint velocity out of limit: " << humanModel.getJointName(i)
                        << " : " << jointVelocitiesSolution.getVal(i);
-            //            jointVelocitiesSolution.setVal(i, -1.0 * max_velocity_val);
+            jointVelocitiesSolution.setVal(i, -1.0 * max_velocity_val);
         }
     }
     yInfo() << "**********************************";

--- a/devices/HumanStateProvider/InverseVelocityKinematics/InverseVelocityKinematics.cpp
+++ b/devices/HumanStateProvider/InverseVelocityKinematics/InverseVelocityKinematics.cpp
@@ -289,8 +289,9 @@ bool InverseVelocityKinematics::impl::solveWeightedPseudoInverse(
         return false;
 
     outputVector.resize(matrix.cols());
-    yInfo() << "reg: " << regularizationMatrix.getVal(1, 1) << regularizationMatrix.getVal(2, 2)
-            << regularizationMatrix.getVal(3, 3) << regularizationMatrix.getVal(4, 4);
+    //    yInfo() << "reg: " << regularizationMatrix.getVal(1, 1) << regularizationMatrix.getVal(2,
+    //    2)
+    //            << regularizationMatrix.getVal(3, 3) << regularizationMatrix.getVal(4, 4);
 
     Eigen::DiagonalMatrix<double, Eigen::Dynamic> weightInverse(weightVector.size());
     weightInverse =
@@ -318,13 +319,24 @@ bool InverseVelocityKinematics::impl::solveWeightedPseudoInverse(
     // simple inversion: // 5-6 msec
     //**************************************************
 
-    //    iDynTree::toEigen(outputVector) =
-    //        (iDynTree::toEigen(matrix).transpose() * weightInverse.toDenseMatrix()
-    //             * iDynTree::toEigen(matrix)
-    //         + iDynTree::toEigen(regularizationMatrix))
-    //            .inverse()
-    //        * iDynTree::toEigen(matrix).transpose() * weightInverse.toDenseMatrix()
-    //        * iDynTree::toEigen(inputVector);
+    iDynTree::toEigen(outputVector) =
+        (iDynTree::toEigen(matrix).transpose() * weightInverse.toDenseMatrix()
+             * iDynTree::toEigen(matrix)
+         + iDynTree::toEigen(regularizationMatrix))
+            .inverse()
+        * iDynTree::toEigen(matrix).transpose() * weightInverse.toDenseMatrix()
+        * iDynTree::toEigen(inputVector);
+    double manipulability = std::sqrt(
+        (iDynTree::toEigen(matrix).transpose() * iDynTree::toEigen(matrix)).determinant());
+    yInfo() << "manipulability: " << manipulability
+            << " , activation: " << (1 - std::tanh(manipulability / 2)) / 2;
+    //    std::cout << "jacobian: " << iDynTree::toEigen(matrix) << std::endl;
+
+    //    std::cout << "eigen values: "
+    //              << (iDynTree::toEigen(matrix).transpose() * iDynTree::toEigen(matrix))
+    //                     .eigenvalues()
+    //                     .transpose()
+    //              << std::endl;
 
     //**************************************************
     // Least Square Solving: // 50-60 msec

--- a/devices/HumanStateProvider/InverseVelocityKinematics/InverseVelocityKinematics.cpp
+++ b/devices/HumanStateProvider/InverseVelocityKinematics/InverseVelocityKinematics.cpp
@@ -238,6 +238,7 @@ bool InverseVelocityKinematics::impl::solveProblem()
         jointVelocityResult.setVal(k, nu.getVal(k + 6));
     }
 
+
     double max_velocity_val = 10.0;
     // Add here the joint velocity limits
     for (unsigned i = 0; i < jointVelocityResult.size(); i++) {
@@ -247,6 +248,7 @@ bool InverseVelocityKinematics::impl::solveProblem()
             iDynTree::iDynTreeEigenMatrixMap fullJacobian = iDynTree::toEigen(fullJacobianBuffer);
             yInfo() << "InverseVelocityKinematics::impl:: jacobian " << fullJacobian.rows()
                     << fullJacobian.cols();
+
             //            yInfo() << "JACOBIAN:";
 
             //            for (unsigned i = 0; i < fullJacobianBuffer.rows(); i++) {
@@ -904,8 +906,7 @@ bool InverseVelocityKinematics::updateAngularVelocityTarget(std::string linkName
 bool InverseVelocityKinematics::getVelocitySolution(iDynTree::Twist& baseVelocity,
                                                     iDynTree::VectorDynSize& jointsVelocity)
 {
-    assert(getJointsVelocitySolution(jointsVelocity) && getBaseVelocitySolution(baseVelocity));
-    return true;
+  return getJointsVelocitySolution(jointsVelocity) && getBaseVelocitySolution(baseVelocity);
 }
 
 bool InverseVelocityKinematics::getJointsVelocitySolution(iDynTree::VectorDynSize& jointsVelocity)

--- a/devices/HumanStateProvider/InverseVelocityKinematics/InverseVelocityKinematics.hpp
+++ b/devices/HumanStateProvider/InverseVelocityKinematics/InverseVelocityKinematics.hpp
@@ -24,7 +24,13 @@ protected:
 public:
     typedef enum
     {
-        pseudoinverse
+        moorePenrose,
+        completeOrthogonalDecomposition,
+        leastSquare,
+        choleskyDecomposition,
+        sparseCholeskyDecomposition,
+        robustCholeskyDecomposition,
+        sparseRobustCholeskyDecomposition,
     } InverseVelocityKinematicsResolutionMode;
 
     InverseVelocityKinematics();
@@ -32,7 +38,8 @@ public:
 
     bool setModel(iDynTree::Model model);
     bool setFloatingBaseOnFrameNamed(std::string floatingBaseFrameName);
-    void setResolutionMode(InverseVelocityKinematicsResolutionMode resolutionMode);
+    bool setResolutionMode(InverseVelocityKinematicsResolutionMode resolutionMode);
+    bool setResolutionMode(std::string resolutionModeName);
     void setRegularization(double regularizationWeight);
 
     bool addTarget(std::string linkName,

--- a/devices/HumanStateProvider/InverseVelocityKinematics/InverseVelocityKinematics.hpp
+++ b/devices/HumanStateProvider/InverseVelocityKinematics/InverseVelocityKinematics.hpp
@@ -13,33 +13,50 @@
 
 #include <map>
 #include <memory>
+#include <yarp/os/LogStream.h>
 
 class InverseVelocityKinematics
 {
 protected:
-	class impl;
+    class impl;
     std::unique_ptr<impl> pImpl;
 
 public:
+    typedef enum
+    {
+        pseudoinverse
+    } InverseVelocityKinematicsResolutionMode;
 
-    typedef enum  {pseudoinverse} InverseVelocityKinematicsResolutionMode;
-
-	InverseVelocityKinematics();
-	~InverseVelocityKinematics();
+    InverseVelocityKinematics();
+    ~InverseVelocityKinematics();
 
     bool setModel(iDynTree::Model model);
     bool setFloatingBaseOnFrameNamed(std::string floatingBaseFrameName);
     void setResolutionMode(InverseVelocityKinematicsResolutionMode resolutionMode);
     void setRegularization(double regularizationWeight);
 
-    bool addTarget(std::string linkName, iDynTree::Vector3 linearVelocity, iDynTree::Vector3  angularVelocity, double linearWeight=1.0, double angularWeight=1.0);
-    bool addTarget(std::string linkName, iDynTree::Twist twist, double linearWeight=1.0, double angularWeight=1.0);
-    bool addLinearVelocityTarget(std::string linkName, iDynTree::Vector3 linearVelocity, double linearWeight=1.0);
-    bool addLinearVelocityTarget(std::string linkName, iDynTree::Twist twist, double linearWeight=1.0);
-    bool addAngularVelocityTarget(std::string linkName, iDynTree::Vector3  angularVelocity, double angularWeight=1.0);
-    bool addAngularVelocityTarget(std::string linkName, iDynTree::Twist  twist, double angularWeight=1.0);
+    bool addTarget(std::string linkName,
+                   iDynTree::Vector3 linearVelocity,
+                   iDynTree::Vector3 angularVelocity,
+                   double linearWeight = 1.0,
+                   double angularWeight = 1.0);
+    bool addTarget(std::string linkName,
+                   iDynTree::Twist twist,
+                   double linearWeight = 1.0,
+                   double angularWeight = 1.0);
+    bool addLinearVelocityTarget(std::string linkName,
+                                 iDynTree::Vector3 linearVelocity,
+                                 double linearWeight = 1.0);
+    bool
+    addLinearVelocityTarget(std::string linkName, iDynTree::Twist twist, double linearWeight = 1.0);
+    bool addAngularVelocityTarget(std::string linkName,
+                                  iDynTree::Vector3 angularVelocity,
+                                  double angularWeight = 1.0);
+    bool addAngularVelocityTarget(std::string linkName,
+                                  iDynTree::Twist twist,
+                                  double angularWeight = 1.0);
 
-    //TODO
+    // TODO
     // addFrameVelocityConstraint
     // addFrameLinearVelocityConstraint
     // addFrameAngularVelocityConstraint
@@ -48,29 +65,44 @@ public:
     bool setJointsConfiguration(iDynTree::VectorDynSize jointsConfiguration);
     bool setBasePose(iDynTree::Transform baseTransform);
     bool setBasePose(iDynTree::Vector3 basePosition, iDynTree::Rotation baseRotation);
-    bool setConfiguration(iDynTree::Transform baseTransform, iDynTree::VectorDynSize jointsConfiguration);
-    bool setConfiguration(iDynTree::Vector3 basePosition, iDynTree::Rotation baseRotation, iDynTree::VectorDynSize jointsConfiguration);
+    bool setConfiguration(iDynTree::Transform baseTransform,
+                          iDynTree::VectorDynSize jointsConfiguration);
+    bool setConfiguration(iDynTree::Vector3 basePosition,
+                          iDynTree::Rotation baseRotation,
+                          iDynTree::VectorDynSize jointsConfiguration);
 
-    //TODO
+    // TODO
     // setBaseVelocityLimit
     // setBaseLinearVelocityLimit
     // setBaseAngularVelocityLimit
     // setJointVelocityLimit
     // setJointsVelocityLimit
 
-    bool updateTarget(std::string linkName, iDynTree::Vector3 linearVelocity, iDynTree::Vector3  angularVelocity, double linearWeight=1.0, double angularWeight=1.0);
-    bool updateTarget(std::string linkName, iDynTree::Twist twist, double linearWeight=1.0, double angularWeight=1.0);
-    bool updateLinearVelocityTarget(std::string linkName, iDynTree::Vector3 linearVelocity, double linearWeight=1.0);
-    bool updateAngularVelocityTarget(std::string linkName, iDynTree::Vector3  angularVelocity, double angularWeight=1.0);
+    bool updateTarget(std::string linkName,
+                      iDynTree::Vector3 linearVelocity,
+                      iDynTree::Vector3 angularVelocity,
+                      double linearWeight = 1.0,
+                      double angularWeight = 1.0);
+    bool updateTarget(std::string linkName,
+                      iDynTree::Twist twist,
+                      double linearWeight = 1.0,
+                      double angularWeight = 1.0);
+    bool updateLinearVelocityTarget(std::string linkName,
+                                    iDynTree::Vector3 linearVelocity,
+                                    double linearWeight = 1.0);
+    bool updateAngularVelocityTarget(std::string linkName,
+                                     iDynTree::Vector3 angularVelocity,
+                                     double angularWeight = 1.0);
 
-    bool getVelocitySolution(iDynTree::Twist& baseVelocity, iDynTree::VectorDynSize& jointsVelocity);
+    bool getVelocitySolution(iDynTree::Twist& baseVelocity,
+                             iDynTree::VectorDynSize& jointsVelocity);
     bool getJointsVelocitySolution(iDynTree::VectorDynSize& jointsVelocity);
     bool getBaseVelocitySolution(iDynTree::Twist& baseVelocity);
-    bool getBaseVelocitySolution(iDynTree::Vector3& linearVelocity, iDynTree::Vector3& angularVelocity);
+    bool getBaseVelocitySolution(iDynTree::Vector3& linearVelocity,
+                                 iDynTree::Vector3& angularVelocity);
 
     bool solve();
     void clearProblem();
 };
-
 
 #endif // INVERSEVELOCITYKINEMATICS_HPP

--- a/devices/Utilities/Utils.cpp
+++ b/devices/Utilities/Utils.cpp
@@ -179,6 +179,10 @@ void iDynTreeHelper::State::integrator::setNJoints(unsigned int _nJoints)
     nJoints = _nJoints;
     oldState.s.resize(nJoints);
     oldState.dot_s.resize(nJoints);
+    oldState.dot_dot_s.resize(nJoints);
+    oldState.s.zero();
+    oldState.dot_s.zero();
+    oldState.dot_dot_s.zero();
 
     resetState();
     resetJointLimits();
@@ -326,7 +330,7 @@ void iDynTreeHelper::State::integrator::integrate(iDynTree::VectorDynSize new_do
 
     if (interpolator == rectangular)
     {
-        for(int i; i<new_dot_s.size(); i++)
+        for(int i = 0; i<new_dot_s.size(); i++)
         {
             oldState.s.setVal(i, oldState.s.getVal(i) + new_dot_s.getVal(i) * dt);
             if (jointLimits.active)
@@ -339,7 +343,7 @@ void iDynTreeHelper::State::integrator::integrate(iDynTree::VectorDynSize new_do
     }
     else if (interpolator == trapezoidal)
     {
-        for(int i; i<new_dot_s.size(); i++)
+        for(int i = 0 ; i<new_dot_s.size(); i++)
         {
             oldState.s.setVal(i, oldState.s.getVal(i) + (oldState.dot_s.getVal(i) + new_dot_s.getVal(i)) * dt /2);
             if (jointLimits.active)
@@ -368,14 +372,14 @@ void iDynTreeHelper::State::integrator::integrate(iDynTree::VectorDynSize new_do
     //integrate base position
     if (interpolator == rectangular)
     {
-        for(int i; i<3; i++)
+        for(int i = 0; i<3; i++)
         {
             oldState.W_p_B.setVal(i, oldState.W_p_B.getVal(i) + new_dot_W_p_B.getVal(i) * dt);
         }
     }
     else if (interpolator == trapezoidal)
     {
-        for(int i; i<3; i++)
+        for(int i = 0; i<3; i++)
         {
             oldState.W_p_B.setVal(i, oldState.W_p_B.getVal(i) + (oldState.dot_W_p_B.getVal(i) + new_dot_W_p_B.getVal(i)) * dt /2);
         }


### PR DESCRIPTION
With this PR I am cleaning the `HumanStateProvider` merging also the changes from [`feature/integration_IK_singularity`](https://github.com/robotology/human-dynamics-estimation/tree/feature/integration_IK_singularity).

Now, from the configuration file it is possible to choose:
- `inverseVelocityKinematicsSolver` with the following options to solve the pseudoinverse:
  - moorePenrose
  - completeOrthogonalDecomposition
  - leastSquare
  - choleskyDecomposition
  - sparseCholeskyDecomposition
  - robustCholeskyDecomposition
  - sparseRobustCholeskyDecomposition
- `integrationBasedJointVelocityLimit`: treshold for the computed joint velocities that is applied in the `HumanStateProvider` (https://github.com/lrapetti/human-dynamics-estimation/blob/improve-HumanStateProvider/devices/HumanStateProvider/HumanStateProvider.cpp#L1432)