### PR TITLE
Add icub-main to CI

### DIFF
--- a/.ci/build_deps.sh
+++ b/.ci/build_deps.sh
@@ -46,7 +46,7 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
     cmake .. \
         -G"$TRAVIS_CMAKE_GENERATOR" \
         -DCMAKE_BUILD_TYPE=$TRAVIS_BUILD_TYPE \
-        -DCMAKE_INSTALL_PREFIX=$DEPS_INSTALL_PREFIX \
+        -DCMAKE_INSTALL_PREFIX=$DEPS_INSTALL_PREFIX
     cmake --build . --config $TRAVIS_BUILD_TYPE --target install
 
     # Build and install idyntree

--- a/.ci/build_deps.sh
+++ b/.ci/build_deps.sh
@@ -47,7 +47,6 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
         -G"$TRAVIS_CMAKE_GENERATOR" \
         -DCMAKE_BUILD_TYPE=$TRAVIS_BUILD_TYPE \
         -DCMAKE_INSTALL_PREFIX=$DEPS_INSTALL_PREFIX \
-        -DCREATE_LIB_MATH=ON
     cmake --build . --config $TRAVIS_BUILD_TYPE --target install
 
     # Build and install idyntree

--- a/.ci/build_deps.sh
+++ b/.ci/build_deps.sh
@@ -35,6 +35,21 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ] ; then
         -DCREATE_LIB_MATH=ON
     cmake --build . --config $TRAVIS_BUILD_TYPE --target install
 
+    # Build and install icub-main
+    cd $GIT_FOLDER
+
+    rm -rf icub-main
+    git clone --depth 1 -b $DEPS_BRANCH https://github.com/robotology/icub-main.git
+    cd icub-main
+    mkdir -p build && cd build
+
+    cmake .. \
+        -G"$TRAVIS_CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=$TRAVIS_BUILD_TYPE \
+        -DCMAKE_INSTALL_PREFIX=$DEPS_INSTALL_PREFIX \
+        -DCREATE_LIB_MATH=ON
+    cmake --build . --config $TRAVIS_BUILD_TYPE --target install
+
     # Build and install idyntree
     cd $GIT_FOLDER
     rm -rf idyntree

--- a/.travis.yml
+++ b/.travis.yml
@@ -153,10 +153,6 @@ jobs:
       after_failure: skip
       after_success: skip
       after_script: skip
-      env:
-        TRAVIS_CMAKE_GENERATOR="Xcode"
-        TRAVIS_BUILD_TYPE="Debug"
-    - <<: *osx_template
       compiler: clang
       env:
         TRAVIS_CMAKE_GENERATOR="Unix Makefiles"

--- a/devices/RobotPositionController/CMakeLists.txt
+++ b/devices/RobotPositionController/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 find_package(IWear REQUIRED)
 find_package(iDynTree REQUIRED)
+find_package(ICUB REQUIRED)
 
 yarp_prepare_plugin(robot_position_controller
     TYPE hde::devices::RobotPositionController


### PR DESCRIPTION
In order to fix the MacOS CI failure discussed in https://github.com/robotology/human-dynamics-estimation/issues/124#issuecomment-501290944, I am adding `icub-main` to `build_deps.sh`.