### PR TITLE
Fix devel windows compilation

### DIFF
--- a/devices/HumanControlBoard/CMakeLists.txt
+++ b/devices/HumanControlBoard/CMakeLists.txt
@@ -19,6 +19,8 @@ yarp_add_plugin(HumanControlBoard
 target_include_directories(HumanControlBoard PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
+add_definitions(-D_USE_MATH_DEFINES)
+
 target_link_libraries(HumanControlBoard PUBLIC
     IHumanState
     IHumanDynamics

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -322,6 +322,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         yError() << LogPrefix << "ikSolver " << solverName << " not found";
         return false;
     }
+	
     yarp::os::Bottle* floatingBaseFrameList = config.find("floatingBaseFrame").asList();
     pImpl->useXsensJointsAngles = config.find("useXsensJointsAngles").asBool();
     const std::string urdfFileName = config.find("urdf").asString();

--- a/devices/RobotPositionController/CMakeLists.txt
+++ b/devices/RobotPositionController/CMakeLists.txt
@@ -20,6 +20,8 @@ yarp_add_plugin(RobotPositionController
 target_include_directories(RobotPositionController PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
+add_definitions(-D_USE_MATH_DEFINES)
+
 target_link_libraries(RobotPositionController PUBLIC
     IHumanState
     YARP::YARP_OS

--- a/devices/RobotPositionController/RobotPositionController.cpp
+++ b/devices/RobotPositionController/RobotPositionController.cpp
@@ -221,7 +221,7 @@ bool RobotPositionController::open(yarp::os::Searchable& config)
             }
 
             // Get initial joint positions from encoders
-            double initEncoderJointPositions[remoteControlBoardJoints];
+            double* initEncoderJointPositions = new double[remoteControlBoardJoints];
             pImpl->iEncoders->getEncoders(initEncoderJointPositions);
 
             yarp::sig::Vector initEncoderJointPositionsVector;
@@ -299,7 +299,7 @@ void RobotPositionController::run()
     if (pImpl->firstDataCheck) {
 
         // Initialize joint position array with a dummy value
-        double jointPositionsArray[pImpl->jointNameListFromConfigControlBoards.size()];
+        double* jointPositionsArray = new double[pImpl->jointNameListFromConfigControlBoards.size()];
 
         // Set the joint position values array for iPositionControl interface
         for (unsigned controlBoardJointIndex = 0; controlBoardJointIndex < pImpl->jointNameListFromConfigControlBoards.size(); controlBoardJointIndex++) {
@@ -327,7 +327,7 @@ void RobotPositionController::run()
             pImpl->iEncoders->getAxes(&joints);
 
             // Read joint position through IEncoder interface
-            double encoderJointPositions[joints];
+            double* encoderJointPositions = new double[joints];
             pImpl->iEncoders->getEncoders(encoderJointPositions);
 
             if (pImpl->controlMode == "position") {


### PR DESCRIPTION
This PR fixes the compilation of the `devel` branch on Windows:
- add `_USE_MATH_DEFINES` definition (with the solution2 proposed in https://github.com/robotology/QA/issues/81)
- remove variable length arrays (related discussion https://stackoverflow.com/questions/33423502/expression-did-not-evaluate-to-a-constant-c)