### PR TITLE
fix HumanStateProvider dependency to Eigen3

### DIFF
--- a/devices/HumanStateProvider/CMakeLists.txt
+++ b/devices/HumanStateProvider/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 find_package(IWear REQUIRED)
 find_package(iDynTree REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 yarp_prepare_plugin(human_state_provider
     TYPE hde::devices::HumanStateProvider


### PR DESCRIPTION
The PR related to bug and solution describe here: https://github.com/robotology/robotology-superbuild/pull/231#issuecomment-519840935

Related to dependency of `humanStateProvider` to `Eigen3`.

CC @lrapetti @Yeshasvitvs @traversaro 