### PR TITLE
Feature: Add base offset parameter to human state publisher, use prefix for transform client and update retargeting robot models configuration files

### DIFF
--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -4,6 +4,11 @@ set (HDE_XML_FILES xml/TransformServer.xml
                    xml/Human.xml
                    xml/pHRI.xml
                    xml/RobotPosePublisher.xml
+                   xml/RobotStateProvider_iCub.xml
+									 xml/RobotStateProvider_Nao.xml
+									 xml/RobotStateProvider_Walkman.xml
+									 xml/RobotStateProvider_Atlas.xml
+									 xml/RobotStateProvider_Baxter.xml
                    xml/HumanJointTorquesYarpScope.xml
                    xml/applications/HumanDynamicsEstimation-HumanDumper.xml)
 
@@ -56,4 +61,3 @@ install(FILES ${ROS_RVIZ_FILES}
 # Install robot urdf files
 install(FILES ${ROBOT_URDF_FILES}
              DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${ROS_PROJECT_NAME}/urdfs/)
-

--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -4,6 +4,7 @@ set (HDE_XML_FILES xml/TransformServer.xml
                    xml/Human.xml
                    xml/pHRI.xml
                    xml/RobotPosePublisher.xml
+                   xml/RobotStateProvider_Human.xml
                    xml/RobotStateProvider_iCub.xml
 									 xml/RobotStateProvider_Nao.xml
 									 xml/RobotStateProvider_Walkman.xml

--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -173,6 +173,8 @@
         <param name="period">0.02</param>
         <param name="baseTFName">/Human/Pelvis</param>
         <param name="humanJointsTopic">/Human/joint_states</param>
+        <param name="basePositionOffset">(0.0 -20.0 0.0)</param>
+	<param name="baseOrientationOffset">(0.0 0.0 0.0 0.0)</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStatePublisherLabel">HumanStateProvider</elem>

--- a/conf/xml/RobotStateProvider_Atlas.xml
+++ b/conf/xml/RobotStateProvider_Atlas.xml
@@ -139,7 +139,7 @@
         <param name="baseTFName">/Atlas/pelvis</param>
         <param name="humanJointsTopic">/Atlas/joint_states</param>
 		<param name="portprefix">atlas</param>
-	    <param name="basePositionOffset">(0.0 -11.0 0.0)</param>
+	    <param name="basePositionOffset">(0.0 -8.0 0.0)</param>
 		<param name="baseOrientationOffset">(0.0 0.0 0.0 0.0)</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/conf/xml/RobotStateProvider_Atlas.xml
+++ b/conf/xml/RobotStateProvider_Atlas.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
-<robot name="Human-HDE" build=0 portprefix="">
+<robot name="Atlas-Retargeting" build=0 portprefix="">
 
-    <device type="transformServer" name="TransformServer">
+    <!--device type="transformServer" name="TransformServer">
         <param name="transforms_lifetime">0.2</param>
         <group name="ROS">
             <param name="enable_ros_publisher">true</param>
             <param name="enable_ros_subscriber">false</param>
         </group>
-    </device>
+    </device-->
 
     <device type="iwear_remapper" name="XSenseIWearRemapper">
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param> 
+        <param name="outputPortName">/Atlas/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">
         <param name="period">0.02</param>
-        <param name="urdf">model.urdf</param>
+        <param name="urdf">atlas.urdf</param>
         <param name="floatingBaseFrame">(pelvis, XsensSuit::vLink::Pelvis)</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
@@ -125,7 +125,7 @@
     <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
     <device type="human_state_wrapper" name="RobotStateWrapper">
         <param name="period">0.01</param>
-        <param name="outputPort">/HDE/RobotStateWrapper/state:o</param>
+        <param name="outputPort">/Atlas/RobotStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStateWrapperLabel">RobotStateProvider</elem>
@@ -136,8 +136,11 @@
 
     <device type="human_state_publisher" name="RobotStatePublisher">
         <param name="period">0.02</param>
-        <param name="baseTFName">/Robot/pelvis</param>
-        <param name="humanJointsTopic">/Robot/joint_states</param>
+        <param name="baseTFName">/Atlas/pelvis</param>
+        <param name="humanJointsTopic">/Atlas/joint_states</param>
+		<param name="portprefix">atlas</param>
+	    <param name="basePositionOffset">(0.0 -11.0 0.0)</param>
+		<param name="baseOrientationOffset">(0.0 0.0 0.0 0.0)</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStatePublisherLabel">RobotStateProvider</elem>

--- a/conf/xml/RobotStateProvider_Baxter.xml
+++ b/conf/xml/RobotStateProvider_Baxter.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
-<robot name="Human-HDE" build=0 portprefix="">
+<robot name="Baxter-Retargeting" build=0 portprefix="">
 
-    <device type="transformServer" name="TransformServer">
+    <!-- <device type="transformServer" name="TransformServer">
         <param name="transforms_lifetime">0.2</param>
         <group name="ROS">
             <param name="enable_ros_publisher">true</param>
             <param name="enable_ros_subscriber">false</param>
         </group>
-    </device>
+    </device> -->
 
     <device type="iwear_remapper" name="XSenseIWearRemapper">
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param> 
+        <param name="outputPortName">/Baxter/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">
         <param name="period">0.02</param>
-        <param name="urdf">model.urdf</param>
+        <param name="urdf">baxter.urdf</param>
         <param name="floatingBaseFrame">(base, XsensSuit::vLink::Pelvis)</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
@@ -118,7 +118,7 @@
     <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
     <device type="human_state_wrapper" name="RobotStateWrapper">
         <param name="period">0.01</param>
-        <param name="outputPort">/HDE/RobotStateWrapper/state:o</param>
+        <param name="outputPort">/Baxter/RobotStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStateWrapperLabel">RobotStateProvider</elem>
@@ -129,8 +129,11 @@
 
     <device type="human_state_publisher" name="RobotStatePublisher">
         <param name="period">0.02</param>
-        <param name="baseTFName">/Robot/base</param>
-        <param name="humanJointsTopic">/Robot/joint_states</param>
+        <param name="baseTFName">/Baxter/base</param>
+        <param name="humanJointsTopic">/Baxter/joint_states</param>
+				<param name="portprefix">baxter</param>
+	      <param name="basePositionOffset">(0.0 -5.0 0.0)</param>
+				<param name="baseOrientationOffset">(0.0 0.0 0.0 0.0)</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStatePublisherLabel">RobotStateProvider</elem>

--- a/conf/xml/RobotStateProvider_Human.xml
+++ b/conf/xml/RobotStateProvider_Human.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<robot name="Human-Retargeting" build=0 portprefix="">
+
+    <device type="transformServer" name="TransformServer">
+        <param name="transforms_lifetime">0.2</param>
+        <group name="ROS">
+            <param name="enable_ros_publisher">true</param>
+            <param name="enable_ros_subscriber">false</param>
+        </group>
+    </device>
+
+    <device type="iwear_remapper" name="XSenseIWearRemapper">
+        <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
+        <param name="useRPC">false</param>
+        <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
+        <param name="outputPortName">/Human/XsensIWearRemapper/data:o</param>
+    </device>
+
+    <device type="human_state_provider" name="HumanStateProvider">
+        <param name="period">0.02</param>
+        <param name="urdf">humanSubject01_66dof.urdf</param>
+        <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
+        <!-- ikSolver options: pairwised, global, integrationbased -->
+        <param name="ikSolver">integrationbased</param>
+        <param name="useXsensJointsAngles">false</param>
+        <param name="allowIKFailures">true</param>
+        <param name="useDirectBaseMeasurement">false</param>
+        <!-- optimization parameters -->
+        <param name="maxIterationsIK">300</param>
+        <param name="ikLinearSolver">ma27</param>
+        <param name="ikPoolSizeOption">2</param>
+        <param name="posTargetWeight">0.0</param>
+        <param name="rotTargetWeight">1.0</param>
+        <param name="costRegularization">0.000001</param>
+        <param name="costTolerance">0.001</param>
+        <!-- inverse velocity kinematics parameters -->
+        <!-- inverseVelocityKinematicsSolver values:
+        moorePenrose,
+        completeOrthogonalDecomposition,
+        leastSquare,
+        choleskyDecomposition,
+        sparseCholeskyDecomposition,
+        robustCholeskyDecomposition,
+        sparseRobustCholeskyDecomposition -->
+        <param name='inverseVelocityKinematicsSolver'>sparseRobustCholeskyDecomposition</param>
+        <param name="linVelTargetWeight">0.0</param>
+        <param name="angVelTargetWeight">1.0</param>
+        <!-- integration based IK parameters -->
+        <param name='integrationBasedJointVelocityLimit'>10.0</param> <!-- comment or -1.0 for no limits -->
+        <param name="integrationBasedIKMeasuredVelocityGainLinRot">(1.0 1.0)</param>
+        <param name="integrationBasedIKCorrectionGainsLinRot">(8.0 20.0)</param>
+        <param name="integrationBasedIKIntegralCorrectionGainsLinRot">(0.0 0.0)</param>
+        <group name="MODEL_TO_DATA_LINK_NAMES">
+            <param name="map_Pelvis">(Pelvis, XsensSuit::vLink::Pelvis)</param>
+            <param name="map_L5">(L5, XsensSuit::vLink::L5)</param>
+            <param name="map_L3">(L3, XsensSuit::vLink::L3)</param>
+            <param name="map_T12">(T12, XsensSuit::vLink::T12)</param>
+            <param name="map_T8">(T8, XsensSuit::vLink::T8)</param>
+            <param name="map_Neck">(Neck, XsensSuit::vLink::Neck)</param>
+            <param name="map_Head">(Head, XsensSuit::vLink::Head)</param>
+            <param name="map_RightShoulder">(RightShoulder, XsensSuit::vLink::RightShoulder)</param>
+            <param name="map_RightUpperArm">(RightUpperArm, XsensSuit::vLink::RightUpperArm)</param>
+            <param name="map_RightForeArm">(RightForeArm, XsensSuit::vLink::RightForeArm)</param>
+            <param name="map_RightHand">(RightHand, XsensSuit::vLink::RightHand)</param>
+            <param name="map_LeftShoulder">(LeftShoulder, XsensSuit::vLink::LeftShoulder)</param>
+            <param name="map_LeftUpperArm">(LeftUpperArm, XsensSuit::vLink::LeftUpperArm)</param>
+            <param name="map_LeftForeArm">(LeftForeArm, XsensSuit::vLink::LeftForeArm)</param>
+            <param name="map_LeftHand">(LeftHand, XsensSuit::vLink::LeftHand)</param>
+            <param name="map_RightUpperLeg">(RightUpperLeg, XsensSuit::vLink::RightUpperLeg)</param>
+            <param name="map_RightLowerLeg">(RightLowerLeg, XsensSuit::vLink::RightLowerLeg)</param>
+            <param name="map_RightFoot">(RightFoot, XsensSuit::vLink::RightFoot)</param>
+            <param name="map_RightToe">(RightToe, XsensSuit::vLink::RightToe)</param>
+            <param name="map_LeftUpperLeg">(LeftUpperLeg, XsensSuit::vLink::LeftUpperLeg)</param>
+            <param name="map_LeftLowerLeg">(LeftLowerLeg, XsensSuit::vLink::LeftLowerLeg)</param>
+            <param name="map_LeftFoot">(LeftFoot, XsensSuit::vLink::LeftFoot)</param>
+            <param name="map_LeftToe">(LeftToe, XsensSuit::vLink::LeftToe)</param>
+        </group>
+        <group name="MODEL_TO_DATA_JOINT_NAMES">
+           <!-- TODO: this groups is here for configuring the data that might initialize the IK. -->
+           <!--       However, the zeros and frames from Xsens might be different and we have to -->
+           <!--       figure this out. -->
+           <!-- Example: (model joint name, wearable sensor name, wearable sensor component) -->
+           <param name="map_jL5S1_rotx">(jL5S1_rotx, XsensSuit::vSJoint::jL5S1, 0)</param>
+           <param name="map_jL5S1_roty">(jL5S1_roty, XsensSuit::vSJoint::jL5S1, 1)</param>
+           <param name="map_jL5S1_rotz">(jL5S1_rotz, XsensSuit::vSJoint::jL5S1, 2)</param>
+           <param name="map_jL4L3_rotx">(jL4L3_rotx, XsensSuit::vSJoint::jL4L3, 0)</param>
+           <param name="map_jL4L3_roty">(jL4L3_roty, XsensSuit::vSJoint::jL4L3, 1)</param>
+           <param name="map_jL4L3_rotz">(jL4L3_rotz, XsensSuit::vSJoint::jL4L3, 2)</param>
+           <param name="map_jL1T12_rotx">(jL1T12_rotx, XsensSuit::vSJoint::jL1T12, 0)</param>
+           <param name="map_jL1T12_roty">(jL1T12_roty, XsensSuit::vSJoint::jL1T12, 1)</param>
+           <param name="map_jL1T12_rotz">(jL1T12_rotz, XsensSuit::vSJoint::jL1T12, 2)</param>
+           <param name="map_jT9T8_rotx">(jT9T8_rotx, XsensSuit::vSJoint::jT9T8, 0)</param>
+           <param name="map_jT9T8_roty">(jT9T8_roty, XsensSuit::vSJoint::jT9T8, 1)</param>
+           <param name="map_jT9T8_rotz">(jT9T8_rotz, XsensSuit::vSJoint::jT9T8, 2)</param>
+           <param name="map_jT1C7_rotx">(jT1C7_rotx, XsensSuit::vSJoint::jT1C7, 0)</param>
+           <param name="map_jT1C7_roty">(jT1C7_roty, XsensSuit::vSJoint::jT1C7, 1)</param>
+           <param name="map_jT1C7_rotz">(jT1C7_rotz, XsensSuit::vSJoint::jT1C7, 2)</param>
+           <param name="map_jC1Head_rotx">(jC1Head_rotx, XsensSuit::vSJoint::jC1Head, 0)</param>
+           <param name="map_jC1Head_roty">(jC1Head_roty, XsensSuit::vSJoint::jC1Head, 1)</param>
+           <param name="map_jC1Head_rotz">(jC1Head_rotz, XsensSuit::vSJoint::jC1Head, 2)</param>
+           <!-- Be aware that here the names differ: C7 ==> T4 -->
+           <param name="map_jRightC7Shoulder_rotx">(jRightC7Shoulder_rotx, XsensSuit::vSJoint::jRightT4Shoulder, 0)</param>
+           <param name="map_jRightC7Shoulder_roty">(jRightC7Shoulder_roty, XsensSuit::vSJoint::jRightT4Shoulder, 1)</param>
+           <param name="map_jRightC7Shoulder_rotz">(jRightC7Shoulder_rotz, XsensSuit::vSJoint::jRightT4Shoulder, 2)</param>
+           <param name="map_jRightShoulder_rotx">(jRightShoulder_rotx, XsensSuit::vSJoint::jRightShoulder, 0)</param>
+           <param name="map_jRightShoulder_roty">(jRightShoulder_roty, XsensSuit::vSJoint::jRightShoulder, 1)</param>
+           <param name="map_jRightShoulder_rotz">(jRightShoulder_rotz, XsensSuit::vSJoint::jRightShoulder, 2)</param>
+           <param name="map_jRightElbow_rotx">(jRightElbow_rotx, XsensSuit::vSJoint::jRightElbow, 0)</param>
+           <param name="map_jRightElbow_roty">(jRightElbow_roty, XsensSuit::vSJoint::jRightElbow, 1)</param>
+           <param name="map_jRightElbow_rotz">(jRightElbow_rotz, XsensSuit::vSJoint::jRightElbow, 2)</param>
+           <param name="map_jRightWrist_rotx">(jRightWrist_rotx, XsensSuit::vSJoint::jRightWrist, 0)</param>
+           <param name="map_jRightWrist_roty">(jRightWrist_roty, XsensSuit::vSJoint::jRightWrist, 1)</param>
+           <param name="map_jRightWrist_rotz">(jRightWrist_rotz, XsensSuit::vSJoint::jRightWrist, 2)</param>
+           <!-- Be aware that here the names differ: C7 ==> T4 -->
+           <param name="map_jLeftC7Shoulder_rotx">(jLeftC7Shoulder_rotx, XsensSuit::vSJoint::jLeftT4Shoulder, 0)</param>
+           <param name="map_jLeftC7Shoulder_roty">(jLeftC7Shoulder_roty, XsensSuit::vSJoint::jLeftT4Shoulder, 1)</param>
+           <param name="map_jLeftC7Shoulder_rotz">(jLeftC7Shoulder_rotz, XsensSuit::vSJoint::jLeftT4Shoulder, 2)</param>
+           <param name="map_jLeftShoulder_rotx">(jLeftShoulder_rotx, XsensSuit::vSJoint::jLeftShoulder, 0)</param>
+           <param name="map_jLeftShoulder_roty">(jLeftShoulder_roty, XsensSuit::vSJoint::jLeftShoulder, 1)</param>
+           <param name="map_jLeftShoulder_rotz">(jLeftShoulder_rotz, XsensSuit::vSJoint::jLeftShoulder, 2)</param>
+           <param name="map_jLeftElbow_rotx">(jLeftElbow_rotx, XsensSuit::vSJoint::jLeftElbow, 0)</param>
+           <param name="map_jLeftElbow_roty">(jLeftElbow_roty, XsensSuit::vSJoint::jLeftElbow, 1)</param>
+           <param name="map_jLeftElbow_rotz">(jLeftElbow_rotz, XsensSuit::vSJoint::jLeftElbow, 2)</param>
+           <param name="map_jLeftWrist_rotx">(jLeftWrist_rotx, XsensSuit::vSJoint::jLeftWrist, 0)</param>
+           <param name="map_jLeftWrist_roty">(jLeftWrist_roty, XsensSuit::vSJoint::jLeftWrist, 1)</param>
+           <param name="map_jLeftWrist_rotz">(jLeftWrist_rotz, XsensSuit::vSJoint::jLeftWrist, 2)</param>
+           <param name="map_jRightHip_rotx">(jRightHip_rotx, XsensSuit::vSJoint::jRightHip, 0)</param>
+           <param name="map_jRightHip_roty">(jRightHip_roty, XsensSuit::vSJoint::jRightHip, 1)</param>
+           <param name="map_jRightHip_rotz">(jRightHip_rotz, XsensSuit::vSJoint::jRightHip, 2)</param>
+           <param name="map_jRightKnee_rotx">(jRightKnee_rotx, XsensSuit::vSJoint::jRightKnee, 0)</param>
+           <param name="map_jRightKnee_roty">(jRightKnee_roty, XsensSuit::vSJoint::jRightKnee, 1)</param>
+           <param name="map_jRightKnee_rotz">(jRightKnee_rotz, XsensSuit::vSJoint::jRightKnee, 2)</param>
+           <param name="map_jRightAnkle_rotx">(jRightAnkle_rotx, XsensSuit::vSJoint::jRightAnkle, 0)</param>
+           <param name="map_jRightAnkle_roty">(jRightAnkle_roty, XsensSuit::vSJoint::jRightAnkle, 1)</param>
+           <param name="map_jRightAnkle_rotz">(jRightAnkle_rotz, XsensSuit::vSJoint::jRightAnkle, 2)</param>
+           <param name="map_jRightBallFoot_rotx">(jRightBallFoot_rotx, XsensSuit::vSJoint::jRightBallFoot, 0)</param>
+           <param name="map_jRightBallFoot_roty">(jRightBallFoot_roty, XsensSuit::vSJoint::jRightBallFoot, 1)</param>
+           <param name="map_jRightBallFoot_rotz">(jRightBallFoot_rotz, XsensSuit::vSJoint::jRightBallFoot, 2)</param>
+           <param name="map_jLeftHip_rotx">(jLeftHip_rotx, XsensSuit::vSJoint::jLeftHip, 0)</param>
+           <param name="map_jLeftHip_roty">(jLeftHip_roty, XsensSuit::vSJoint::jLeftHip, 1)</param>
+           <param name="map_jLeftHip_rotz">(jLeftHip_rotz, XsensSuit::vSJoint::jLeftHip, 2)</param>
+           <param name="map_jLeftKnee_rotx">(jLeftKnee_rotx, XsensSuit::vSJoint::jLeftKnee, 0)</param>
+           <param name="map_jLeftKnee_roty">(jLeftKnee_roty, XsensSuit::vSJoint::jLeftKnee, 1)</param>
+           <param name="map_jLeftKnee_rotz">(jLeftKnee_rotz, XsensSuit::vSJoint::jLeftKnee, 2)</param>
+           <param name="map_jLeftAnkle_rotx">(jLeftAnkle_rotx, XsensSuit::vSJoint::jLeftAnkle, 0)</param>
+           <param name="map_jLeftAnkle_roty">(jLeftAnkle_roty, XsensSuit::vSJoint::jLeftAnkle, 1)</param>
+           <param name="map_jLeftAnkle_rotz">(jLeftAnkle_rotz, XsensSuit::vSJoint::jLeftAnkle, 2)</param>
+           <param name="map_jLeftBallFoot_rotx">(jLeftBallFoot_rotx, XsensSuit::vSJoint::jLeftBallFoot, 0)</param>
+           <param name="map_jLeftBallFoot_roty">(jLeftBallFoot_roty, XsensSuit::vSJoint::jLeftBallFoot, 1)</param>
+           <param name="map_jLeftBallFoot_rotz">(jLeftBallFoot_rotz, XsensSuit::vSJoint::jLeftBallFoot, 2)</param>
+        </group>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="HumanStateProviderLabel">XSenseIWearRemapper</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
+    <!-- <device type="human_state_wrapper" name="HumanStateWrapper">
+        <param name="period">0.02</param>
+        <param name="outputPort">/Human/HumanStateWrapper/state:o</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="HumanStateWrapperLabel">HumanStateProvider</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device> -->
+
+    <device type="human_state_publisher" name="HumanStatePublisher">
+        <param name="period">0.02</param>
+        <param name="baseTFName">/Human/Pelvis</param>
+        <param name="humanJointsTopic">/Human/joint_states</param>
+        <param name="basePositionOffset">(0.0 -20.0 0.0)</param>
+	<param name="baseOrientationOffset">(0.0 0.0 0.0 0.0)</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="HumanStatePublisherLabel">HumanStateProvider</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+</robot>

--- a/conf/xml/RobotStateProvider_Nao.xml
+++ b/conf/xml/RobotStateProvider_Nao.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
-<robot name="Human-HDE" build=0 portprefix="">
+<robot name="Nao-Retargeting" build=0 portprefix="">
 
-    <device type="transformServer" name="TransformServer">
+    <!-- <device type="transformServer" name="TransformServer">
         <param name="transforms_lifetime">0.2</param>
         <group name="ROS">
             <param name="enable_ros_publisher">true</param>
             <param name="enable_ros_subscriber">false</param>
         </group>
-    </device>
+    </device> -->
 
     <device type="iwear_remapper" name="XSenseIWearRemapper">
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param> 
+        <param name="outputPortName">/Nao/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">
         <param name="period">0.02</param>
-        <param name="urdf">model.urdf</param>
+        <param name="urdf">nao.urdf</param>
         <param name="floatingBaseFrame">(base_link, XsensSuit::vLink::Pelvis)</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
@@ -123,26 +123,29 @@
     <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
     <!--device type="human_state_wrapper" name="RobotStateWrapper">
         <param name="period">0.01</param>
-        <param name="outputPort">/HDE/RobotStateWrapper/state:o</param>
+        <param name="outputPort">/Nao/RobotStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStateWrapperLabel">RobotStateProvider</elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device>
+    </device-->
 
     <device type="human_state_publisher" name="RobotStatePublisher">
         <param name="period">0.02</param>
-        <param name="baseTFName">/Robot/base_link</param>
-        <param name="humanJointsTopic">/Robot/joint_states</param>
+        <param name="baseTFName">/Nao/base_link</param>
+        <param name="humanJointsTopic">/Nao/joint_states</param>
+				<param name="portprefix">nao</param>
+	      <param name="basePositionOffset">(0.0 -17.0 0.0)</param>
+	      <param name="baseOrientationOffset">(0.0 0.0 0.0 0.0)</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStatePublisherLabel">RobotStateProvider</elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device-->
+    </device>
 
     <!-- uncomment if you want to use the RobotStateProvider data to control the robot position -->
     <!--device type="robot_position_controller" name="RobotPositionController">

--- a/conf/xml/RobotStateProvider_Nao.xml
+++ b/conf/xml/RobotStateProvider_Nao.xml
@@ -137,7 +137,7 @@
         <param name="baseTFName">/Nao/base_link</param>
         <param name="humanJointsTopic">/Nao/joint_states</param>
 				<param name="portprefix">nao</param>
-	      <param name="basePositionOffset">(0.0 -17.0 0.0)</param>
+	      <param name="basePositionOffset">(0.0 -17.0 -0.75)</param>
 	      <param name="baseOrientationOffset">(0.0 0.0 0.0 0.0)</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/conf/xml/RobotStateProvider_Walkman.xml
+++ b/conf/xml/RobotStateProvider_Walkman.xml
@@ -1,25 +1,25 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+Walkman<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
-<robot name="Human-HDE" build=0 portprefix="">
+<robot name="Walkman-Retargeting" build=0 portprefix="">
 
-    <device type="transformServer" name="TransformServer">
+    <!-- <device type="transformServer" name="TransformServer">
         <param name="transforms_lifetime">0.2</param>
         <group name="ROS">
             <param name="enable_ros_publisher">true</param>
             <param name="enable_ros_subscriber">false</param>
         </group>
-    </device>
+    </device> -->
 
     <device type="iwear_remapper" name="XSenseIWearRemapper">
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param> 
+        <param name="outputPortName">/Walkman/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">
         <param name="period">0.02</param>
-        <param name="urdf">model.urdf</param>
+        <param name="urdf">walkman.urdf</param>
         <param name="floatingBaseFrame">(base_link, XsensSuit::vLink::Pelvis)</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
@@ -136,8 +136,11 @@
 
     <device type="human_state_publisher" name="RobotStatePublisher">
         <param name="period">0.02</param>
-        <param name="baseTFName">/Robot/base_link</param>
-        <param name="humanJointsTopic">/Robot/joint_states</param>
+        <param name="baseTFName">/Walkman/base_link</param>
+        <param name="humanJointsTopic">/Walkman/joint_states</param>
+				<param name="portprefix">walkman</param>
+	      <param name="basePositionOffset">(0.0 -9.0 0.0)</param>
+				<param name="baseOrientationOffset">(0.0 0.0 0.0 0.0)</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStatePublisherLabel">RobotStateProvider</elem>

--- a/conf/xml/RobotStateProvider_Walkman.xml
+++ b/conf/xml/RobotStateProvider_Walkman.xml
@@ -1,4 +1,4 @@
-Walkman<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <robot name="Walkman-Retargeting" build=0 portprefix="">
 
@@ -139,7 +139,7 @@ Walkman<?xml version="1.0" encoding="UTF-8" ?>
         <param name="baseTFName">/Walkman/base_link</param>
         <param name="humanJointsTopic">/Walkman/joint_states</param>
 				<param name="portprefix">walkman</param>
-	      <param name="basePositionOffset">(0.0 -9.0 0.0)</param>
+	      <param name="basePositionOffset">(0.0 -11.0 0.0)</param>
 				<param name="baseOrientationOffset">(0.0 0.0 0.0 0.0)</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/conf/xml/RobotStateProvider_iCub.xml
+++ b/conf/xml/RobotStateProvider_iCub.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<robot name="Human-HDE" build=0 portprefix="">
+<robot name="iCub-Retargeting" build=0 portprefix="">
 
-    <device type="transformServer" name="TransformServer">
+    <!-- <device type="transformServer" name="TransformServer">
         <param name="transforms_lifetime">0.2</param>
         <group name="ROS">
             <param name="enable_ros_publisher">true</param>
             <param name="enable_ros_subscriber">false</param>
         </group>
-    </device>
+    </device> -->
 
     <device type="iwear_remapper" name="XSenseIWearRemapper">
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param>
+        <param name="outputPortName">/iCub/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">
@@ -78,7 +78,7 @@
     <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
     <device type="human_state_wrapper" name="RobotStateWrapper">
         <param name="period">0.01</param>
-        <param name="outputPort">/HDE/RobotStateWrapper/state:o</param>
+        <param name="outputPort">/iCub/RobotStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStateWrapperLabel">RobotStateProvider</elem>
@@ -89,8 +89,11 @@
 
     <device type="human_state_publisher" name="RobotStatePublisher">
         <param name="period">0.02</param>
-        <param name="baseTFName">/Robot/root_link_fake</param>
-        <param name="humanJointsTopic">/Robot/joint_states</param>
+        <param name="baseTFName">/iCub/root_link_fake</param>
+        <param name="humanJointsTopic">/iCub/joint_states</param>
+				<param name="portprefix">icub</param>
+	      <param name="basePositionOffset">(0.0 -14.0 0.0)</param>
+				<param name="baseOrientationOffset">(0.0 0.0 0.0 0.0)</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStatePublisherLabel">RobotStateProvider</elem>

--- a/publishers/HumanStatePublisher/HumanStatePublisher.cpp
+++ b/publishers/HumanStatePublisher/HumanStatePublisher.cpp
@@ -267,7 +267,12 @@ bool HumanStatePublisher::open(yarp::os::Searchable& config)
 
     yarp::os::Property options;
     options.put("device", "transformClient");
-    options.put("local", "/" + DeviceName + "/transformClient");
+    if (hasPortPrefix) {
+        options.put("local", "/" + portPrefix + "/" + DeviceName + "/transformClient");
+    }
+    else {
+        options.put("local", "/" + DeviceName + "/transformClient");
+    }
     options.put("remote", "/transformServer");
 
     if (!pImpl->transformClientDevice.open(options)) {


### PR DESCRIPTION
This PR adds the following features:
- Base offset parameters to human state publisher https://github.com/robotology/human-dynamics-estimation/commit/423be153075c016234f8601ed2d290fa1b163c9f
- Add port prefix to transform client in human state publisher https://github.com/robotology/human-dynamics-estimation/commit/2461866c19e77707cef1517890ff9b884df1d605
- Update retargeting robot models configuration files https://github.com/robotology/human-dynamics-estimation/commit/f118b841fa25e6f4c49c5ac902fb83481e8da451 https://github.com/robotology/human-dynamics-estimation/commit/0e00dc61495ac53fad84fa3beb85214bbbfbc3fc

@lrapetti @kouroshD 