### PR TITLE
Add base pose offset

### DIFF
--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -1,30 +1,12 @@
 # HDE xml files installation
 set (HDE_PROJECT_NAME HumanDynamicsEstimation)
-set (HDE_XML_FILES xml/TransformServer.xml
-                   xml/Human.xml
-                   xml/pHRI.xml
-                   xml/RobotPosePublisher.xml
-                   xml/RobotStateProvider_Human.xml
-                   xml/RobotStateProvider_iCub.xml
-									 xml/RobotStateProvider_Nao.xml
-									 xml/RobotStateProvider_Walkman.xml
-									 xml/RobotStateProvider_Atlas.xml
-									 xml/RobotStateProvider_Baxter.xml
-                   xml/HumanJointTorquesYarpScope.xml
-                   xml/applications/HumanDynamicsEstimation-HumanDumper.xml)
-
+file(GLOB HDE_XML_FILES xml/applications/*.xml)
 install(FILES ${HDE_XML_FILES}
              DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${HDE_PROJECT_NAME}/)
 
 # Install yarpmanager application files
-set(HDE_APP_FILES xml/applications/HumanDynamicsEstimation.xml
-                  xml/applications/HumanDynamicsEstimation-Human.xml
-	                xml/applications/HumanDynamicsEstimation-pHRI.xml
-		              xml/applications/HumanDynamicsEstimation-Rviz.xml
-	                xml/applications/HumanDynamicsEstimation-TransformServer.xml
-		              xml/applications/HumanDynamicsEstimation-YarpScope.xml)
-
-yarp_install(FILES ${HDE_APP_FILES} DESTINATION ${YARP_APPLICATIONS_INSTALL_DIR})
+file(GLOB applications xml/applications/*.xml)
+yarp_install(FILES ${applications} DESTINATION ${YARP_APPLICATIONS_INSTALL_DIR})
 
 # Install robot urdf files
 set(ROBOT_URDF_FILES urdfs/iCubGenova02.urdf

--- a/conf/cluster-config.xml
+++ b/conf/cluster-config.xml
@@ -1,6 +1,6 @@
 <cluster name="HDE" user="yeshi">
 
-<nameserver namespace="/Xsens" node="localhost"> </nameserver>
+<nameserver namespace="/icub0" node="localhost"> </nameserver>
 
 <!-- specify nodes, if you want to enable display on desktop please specify which desktop to use
 this is usually the value of the DISPLAY variable when logged on -->

--- a/conf/xml/HumanStateProvider_1.xml
+++ b/conf/xml/HumanStateProvider_1.xml
@@ -2,24 +2,16 @@
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <robot name="Human-HDE" build=0 portprefix="">
 
-    <device type="transformServer" name="TransformServer">
-        <param name="transforms_lifetime">0.2</param>
-        <group name="ROS">
-            <param name="enable_ros_publisher">true</param>
-            <param name="enable_ros_subscriber">false</param>
-        </group>
-    </device>
-
-    <device type="iwear_remapper" name="XSenseIWearRemapper">
+    <device type="iwear_remapper" name="XSenseIWearRemapper_1">
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
         <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param>
     </device>
 
-    <device type="human_state_provider" name="HumanStateProvider">
+    <device type="human_state_provider" name="HumanStateProvider_1">
         <param name="period">0.02</param>
-        <param name="urdf">humanSubject01_66dof.urdf</param>
+        <param name="urdf">humanSubject03_66dof.urdf</param>
         <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
@@ -34,6 +26,7 @@
         <param name="rotTargetWeight">1.0</param>
         <param name="costRegularization">0.000001</param>
         <param name="costTolerance">0.001</param>
+        <param name="rpcPortPrefix">first</param>
         <!-- inverse velocity kinematics parameters -->
         <!-- inverseVelocityKinematicsSolver values:
         moorePenrose,
@@ -152,31 +145,33 @@
         </group>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
-                <elem name="HumanStateProviderLabel">XSenseIWearRemapper</elem>
+                <elem name="HumanStateProviderLabel">XSenseIWearRemapper_1</elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
     <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
-    <!-- <device type="human_state_wrapper" name="HumanStateWrapper">
+    <device type="human_state_wrapper" name="HumanStateWrapper_1">
         <param name="period">0.02</param>
-        <param name="outputPort">/HDE/HumanStateWrapper/state:o</param>
+        <param name="outputPort">/HDE_1/HumanStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
-                <elem name="HumanStateWrapperLabel">HumanStateProvider</elem>
+                <elem name="HumanStateWrapperLabel">HumanStateProvider_1</elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device> -->
+    </device>
 
-    <device type="human_state_publisher" name="HumanStatePublisher">
+    <device type="human_state_publisher" name="HumanStatePublisher_1">
         <param name="period">0.02</param>
-        <param name="baseTFName">/Human/Pelvis</param>
-        <param name="humanJointsTopic">/Human/joint_states</param>
+        <param name="baseTFName">/Human_1/Pelvis</param>
+        <param name="humanJointsTopic">/Human_1/joint_states</param>
+        <param name="portprefix">first</param>
+        <param name="basePositionOffset">(0.0 0.0 0.0)</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
-                <elem name="HumanStatePublisherLabel">HumanStateProvider</elem>
+                <elem name="HumanStatePublisherLabel">HumanStateProvider_1</elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>

--- a/conf/xml/HumanStateProvider_2.xml
+++ b/conf/xml/HumanStateProvider_2.xml
@@ -2,24 +2,16 @@
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <robot name="Human-HDE" build=0 portprefix="">
 
-    <device type="transformServer" name="TransformServer">
-        <param name="transforms_lifetime">0.2</param>
-        <group name="ROS">
-            <param name="enable_ros_publisher">true</param>
-            <param name="enable_ros_subscriber">false</param>
-        </group>
-    </device>
-
-    <device type="iwear_remapper" name="XSenseIWearRemapper">
-        <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
+    <device type="iwear_remapper" name="XSenseIWearRemapper_2">
+        <param name="wearableDataPorts">(/XSensSuit/WearableData_2/data:o)</param>
         <param name="useRPC">false</param>
-        <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param>
+        <param name="wearableRPCPorts">(/XSensSuit/WearableData_2/metadataRpc:o)</param>
+        <param name="outputPortName">/HDE_2/XsensIWearRemapper/data:o</param>
     </device>
 
-    <device type="human_state_provider" name="HumanStateProvider">
+    <device type="human_state_provider" name="HumanStateProvider_2">
         <param name="period">0.02</param>
-        <param name="urdf">humanSubject01_66dof.urdf</param>
+        <param name="urdf">humanSubject05_66dof.urdf</param>
         <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
@@ -34,6 +26,7 @@
         <param name="rotTargetWeight">1.0</param>
         <param name="costRegularization">0.000001</param>
         <param name="costTolerance">0.001</param>
+        <param name="rpcPortPrefix">second</param>
         <!-- inverse velocity kinematics parameters -->
         <!-- inverseVelocityKinematicsSolver values:
         moorePenrose,
@@ -152,31 +145,33 @@
         </group>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
-                <elem name="HumanStateProviderLabel">XSenseIWearRemapper</elem>
+                <elem name="HumanStateProviderLabel">XSenseIWearRemapper_2</elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
     <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
-    <!-- <device type="human_state_wrapper" name="HumanStateWrapper">
+    <device type="human_state_wrapper" name="HumanStateWrapper_2">
         <param name="period">0.02</param>
-        <param name="outputPort">/HDE/HumanStateWrapper/state:o</param>
+        <param name="outputPort">/HDE_2/HumanStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
-                <elem name="HumanStateWrapperLabel">HumanStateProvider</elem>
+                <elem name="HumanStateWrapperLabel">HumanStateProvider_2</elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device> -->
+    </device>
 
-    <device type="human_state_publisher" name="HumanStatePublisher">
+    <device type="human_state_publisher" name="HumanStatePublisher_2">
         <param name="period">0.02</param>
-        <param name="baseTFName">/Human/Pelvis</param>
-        <param name="humanJointsTopic">/Human/joint_states</param>
+        <param name="baseTFName">/Human_2/Pelvis</param>
+        <param name="humanJointsTopic">/Human_2/joint_states</param>
+        <param name="portprefix">second</param>
+        <param name="basePositionOffset">(0.0 0.0 0.0)</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
-                <elem name="HumanStatePublisherLabel">HumanStateProvider</elem>
+                <elem name="HumanStatePublisherLabel">HumanStateProvider_2</elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>

--- a/conf/xml/TransformServer.xml
+++ b/conf/xml/TransformServer.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <robot name="Transform-Server" build=0 portprefix="">
 
     <device type="transformServer" name="TransformServer">

--- a/conf/xml/applications/twoHumansIK.xml
+++ b/conf/xml/applications/twoHumansIK.xml
@@ -1,0 +1,106 @@
+<application>
+  <name>twoHumansIK</name>
+  <description>An application for running Inverse Kinematics of two Human Subjects</description>
+
+  <module>
+    <name>yarplogger</name>
+    <parameters>--start --no_stop</parameters>
+    <description>Run yarplogger</description>
+    <node>localhost</node>
+  </module>
+
+  <!--yarprobotinterface for transform server-->
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--config TransformServer.xml</parameters>
+    <dependencies>
+          <port timeout="5.0">/ros</port>
+    </dependencies>
+    <environment>YARP_FORWARD_LOG_ENABLE=1</environment>
+    <description>Run transform server</description>
+    <node>localhost</node>
+  </module>
+
+  <!--yarprobotinterface configuration for the first Human-->
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--config HumanStateProvider_1.xml</parameters>
+    <dependencies>
+          <port timeout="5.0">/transformServer/rpc</port>
+          <port timeout="5.0">/transformServer/transforms:o</port>
+          <port timeout="5.0">/XSensSuit/WearableData/data:o</port>
+    </dependencies>
+    <environment>YARP_FORWARD_LOG_ENABLE=1</environment>
+    <description>Run IK for first human</description>
+    <node>localhost</node>
+  </module>
+
+  <!--yarprobotinterface configuration for the first Human-->
+  <module>
+    <name>yarprobotinterface</name>
+    <parameters>--config HumanStateProvider_2.xml</parameters>
+    <dependencies>
+          <port timeout="5.0">/transformServer/rpc</port>
+          <port timeout="5.0">/transformServer/transforms:o</port>
+          <port timeout="5.0">/XSensSuit/WearableData_2/data:o</port>
+    </dependencies>
+    <environment>YARP_FORWARD_LOG_ENABLE=1</environment>
+    <description>Run IK for first human</description>
+    <node>localhost</node>
+  </module>
+
+  <!--yarpdatadumper configuration for the first Human-->
+  <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /human_dump/humanState_1 --type bottle --txTime --rxTime</parameters>
+        <node>localhost</node>
+	      <tag>yarpdatadumper</tag>
+  </module>
+
+  <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /human_dump/wearable_1/xsens --type bottle --txTime --rxTime</parameters>
+        <node>${generic_node}</node>
+        <tag>yarpdatadumper</tag>
+  </module>
+
+  <!--yarpdatadumper configuration for the second Human-->
+  <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /human_dump/humanState_2 --type bottle --txTime --rxTime</parameters>
+        <node>localhost</node>
+	      <tag>yarpdatadumper</tag>
+  </module>
+
+  <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /human_dump/wearable_2/xsens --type bottle --txTime --rxTime</parameters>
+        <node>${generic_node}</node>
+        <tag>yarpdatadumper</tag>
+  </module>
+
+  <connection>
+        <from>/HDE_1/HumanStateWrapper/state:o</from>
+        <to>/human_dump/humanState_1</to>
+        <protocol>udp</protocol>
+  </connection>
+
+  <connection>
+        <from>/HDE_2/HumanStateWrapper/state:o</from>
+        <to>/human_dump/humanState_2</to>
+        <protocol>udp</protocol>
+  </connection>
+
+  <connection>
+        <from>/XSensSuit/WearableData/data:o</from>
+        <to>/human_dump/wearable_1/xsens</to>
+        <protocol>udp</protocol>
+  </connection>
+
+  <connection>
+        <from>/XSensSuit/WearableData_2/data:o</from>
+        <to>/human_dump/wearable_2/xsens</to>
+        <protocol>udp</protocol>
+  </connection>
+
+</application>

--- a/conf/xml/twoIWearWrapper.xml
+++ b/conf/xml/twoIWearWrapper.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="Human-HDE" build=0 portprefix="">
+
+    <!--Uncomment the following code if you need to dump wearable data-->
+    <device type="iwear_remapper" name="WearableData">
+        <param name="wearableDataPorts">(/FTShoeLeft/WearableData/data:o /FTShoeRight/WearableData/data:o)</param>
+        <param name="useRPC">false</param>
+        <param name="wearableRPCPorts">(/FTShoeLeft/WearableData/metadataRpc:o /FTShoeRight/WearableData/metadataRpc:o)</param>
+        <param name="outputPortName">/IWearRemapper/data:o</param>
+    </device>
+    <device type="iwear_remapper" name="WearableData2">
+        <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
+        <param name="useRPC">false</param>
+        <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
+        <param name="outputPortName">/IWearRemapper2/data:o</param>
+    </device>
+
+    <device type="iwear_wrapper" name="WearableDataWrapper">
+        <param name="period">0.1</param>
+        <param name="dataPortName">/WearableData/data:o</param>
+        <param name="rpcPortName">/WearableData/metadataRpc:o</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="WearableDataWrapper">WearableData</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+    <device type="iwear_wrapper" name="WearableDataWrapper2">
+        <param name="period">0.1</param>
+        <param name="dataPortName">/WearableData2/data:o</param>
+        <param name="rpcPortName">/WearableData2/metadataRpc:o</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="WearableDataWrapper">WearableData2</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+</robot>

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -22,6 +22,8 @@
 
 #include <yarp/os/LogStream.h>
 #include <yarp/os/ResourceFinder.h>
+#include <yarp/os/RpcServer.h>
+#include <yarp/os/Vocab.h>
 
 #include <array>
 #include <atomic>
@@ -150,6 +152,124 @@ struct HumanSensorData
     std::vector<std::array<double, 6>> accelerometerSensorMeasurements;
 };
 
+class CmdParser : public yarp::os::PortReader
+{
+
+public:
+    std::array<std::atomic_bool,3> positionOffsetFlag{{ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false)}};
+    std::array<std::atomic_bool,3> orientationOffsetFlag{{ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false), ATOMIC_VAR_INIT(false)}};
+    std::atomic<bool> cmdStatus{false};
+
+    bool read(yarp::os::ConnectionReader& connection) override
+    {
+        yarp::os::Bottle command, response;
+        if (command.read(connection)) {
+
+            if (command.get(0).asString() == "help") {
+                response.addVocab(yarp::os::Vocab::encode("many"));
+                response.addString("Enter <removePositionOffset> to remove the base position offset from all the axis \n"
+                                   "   or <removePositionOffset> <axis> <axis_list> for removing position offset of specific axis (e.g. 'removePositionOffset axis xy') \n"
+                                   "Enter <removeOrientationOffset> to remove the base orientation offset \n"
+                                   "   or <removeOrientationOffset> <axis> <axis_list> for removing orientatino offset on specific axis \n"
+                                   "Enter <resetPositionOffset> to reset the base position \n"
+                                   "Enter <resetOrientationOffset> to reset the base orientation \n"
+                                   "Enter <resetOffset> to reset the base position and orientation"
+                                    );
+            }
+            else if (command.get(0).asString() == "removePositionOffset") {
+                if (command.size() == 1) {
+                    response.addString("Entered command <removePositionOffset> is correct, removing position offset for all the axis");
+                    this->positionOffsetFlag.at(0) = true;
+                    this->positionOffsetFlag.at(1) = true;
+                    this->positionOffsetFlag.at(2) = true;
+                    this->cmdStatus = true;
+                }
+                else if (command.get(1).isString() && command.get(1).asString() == "axis" && command.get(2).isString()) {
+                    response.addString("Entered command <removePositionOffset> is correct, removing position offset for the selected axis");
+                    std::string axis = command.get(2).asString();
+                    if (axis.find('x')!=std::string::npos)
+                         this->positionOffsetFlag[0] = true;
+                    if (axis.find('y')!=std::string::npos)
+                         this->positionOffsetFlag[1] = true;
+                    if (axis.find('z')!=std::string::npos)
+                         this->positionOffsetFlag[2] = true;
+                    this->cmdStatus = true;
+                }
+                else {
+                    response.addString(
+                        "Entered command is incorrect, Enter help to know available commands");
+                }
+            }
+            else if (command.get(0).asString() == "removeOrientationOffset") {
+                if (command.size() == 1) {
+                    response.addString("Entered command <removeOrientationOffset> is correct, removing orientation offset for all the axis");
+                    this->orientationOffsetFlag.at(0) = true;
+                    this->orientationOffsetFlag.at(1) = true;
+                    this->orientationOffsetFlag.at(2) = true;
+                    this->cmdStatus = true;
+                }
+                else if (command.get(1).isString() && command.get(1).asString() == "axis" && command.get(2).isString()) {
+                    response.addString("Entered command <removeOrientationOffset> is correct, removing orientation offset for the selected axis");
+                    std::string axis = command.get(2).asString();
+                    if (axis.find('x')!=std::string::npos)
+                         this->orientationOffsetFlag[0] = true;
+                    if (axis.find('y')!=std::string::npos)
+                         this->orientationOffsetFlag[1] = true;
+                    if (axis.find('z')!=std::string::npos)
+                         this->orientationOffsetFlag[2] = true;
+                    this->cmdStatus = true;
+                }
+                else {
+                    response.addString(
+                        "Entered command is incorrect, Enter help to know available commands");
+                }
+            }
+            else if (command.get(0).asString() == "resetPositionOffset") {
+                response.addString("Entered command <resetPositionOffset> is correct, resetting the position offset");
+                this->positionOffsetFlag.at(0) = false;
+                this->positionOffsetFlag.at(1) = false;
+                this->positionOffsetFlag.at(2) = false;
+                this->cmdStatus = true;
+            }
+            else if (command.get(0).asString() == "resetOrientationOffset") {
+                response.addString("Entered command <resetOrientationOffset> is correct, resetting the orientation offset");
+                this->orientationOffsetFlag.at(0) = false;
+                this->orientationOffsetFlag.at(1) = false;
+                this->orientationOffsetFlag.at(2) = false;
+                this->cmdStatus = true;
+            }
+            else if (command.get(0).asString() == "resetOffset") {
+                response.addString("Entered command <resetOffset> is correct, resetting position and orientation offsets");
+                this->positionOffsetFlag.at(0) = false;
+                this->positionOffsetFlag.at(1) = false;
+                this->positionOffsetFlag.at(2) = false;
+                this->orientationOffsetFlag.at(0) = false;
+                this->orientationOffsetFlag.at(1) = false;
+                this->orientationOffsetFlag.at(2) = false;
+                this->cmdStatus = true;
+            }
+            else {
+                response.addString(
+                    "Entered command is incorrect, Enter help to know available commands");
+            }
+        }
+        else {
+            this->cmdStatus = false;
+            return false;
+        }
+
+        yarp::os::ConnectionWriter* reply = connection.getWriter();
+
+        if (reply != NULL) {
+            response.write(*reply);
+        }
+        else
+            return false;
+
+        return true;
+    }
+};
+
 class HumanStateProvider::impl
 {
 public:
@@ -173,6 +293,10 @@ public:
     std::vector<SegmentInfo> segments;
     std::vector<LinkPairInfo> linkPairs;
 
+    // Rpc
+    CmdParser commandPro;
+    yarp::os::RpcServer rpcPort;
+
     // Link wearable data buffers
     std::unordered_map<std::string, iDynTree::Transform> linkTransformMatrices;
     std::unordered_map<std::string, iDynTree::Twist> linkVelocities;
@@ -189,6 +313,12 @@ public:
 
     iDynTree::Vector3 integralOrientationError;
     iDynTree::Vector3 integralLinearVelocityError;
+
+    // Offsets
+    iDynTree::Position basePositionOffset;
+    std::array<bool,3> basePositionOffsetFlag;
+    iDynTree::Vector3 baseOrientationOffsetRPY;
+    std::array<bool,3> baseOrientationOffsetFlag;
 
     std::unordered_map<std::string, iDynTreeHelper::Rotation::rotationDistance>
         linkErrorOrientations;
@@ -470,6 +600,19 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         }
 
     }
+
+    // ===================
+    // INITIALIZE RPC PORT
+    // ===================
+
+    std::string rpcPortName = "/" + DeviceName + "/rpc:i";
+    if (!pImpl->rpcPort.open(rpcPortName)) {
+        yError() << LogPrefix << "Unable to open rpc port " << rpcPortName;
+        return false;
+    }
+
+    // Set rpc port reader
+    pImpl->rpcPort.setReader(pImpl->commandPro);
 
     // =======================================
     // PARSE THE GENERAL CONFIGURATION OPTIONS
@@ -852,6 +995,11 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
 
     pImpl->baseTransformSolution.setRotation(iDynTree::Rotation::Identity());
 
+    pImpl->basePositionOffset.zero();
+    pImpl->baseOrientationOffsetFlag.fill(false);
+    pImpl->baseOrientationOffsetRPY.zero();
+    pImpl->basePositionOffsetFlag.fill(false);
+
     // ====================================
     // INITIALIZE INVERSE KINEMATICS SOLVER
     // ====================================
@@ -1153,6 +1301,14 @@ void HumanStateProvider::run()
 
     }
 
+    // Set the offsets for the base
+    iDynTree::Transform baseTrasfromSolutionAfterOffset;
+    baseTrasfromSolutionAfterOffset.setPosition(pImpl->baseTransformSolution.getPosition() - pImpl->basePositionOffset);
+    iDynTree::Vector3 baseTransformSolutionRPY= pImpl->baseTransformSolution.getRotation().asRPY();
+    baseTrasfromSolutionAfterOffset.setRotation(iDynTree::Rotation::RotZ(pImpl->baseOrientationOffsetRPY.getVal(2)).inverse() * iDynTree::Rotation::RotZ(baseTransformSolutionRPY.getVal(2)) *
+                                                iDynTree::Rotation::RotZ(pImpl->baseOrientationOffsetRPY.getVal(1)).inverse() * iDynTree::Rotation::RotZ(baseTransformSolutionRPY.getVal(1)) *
+                                                iDynTree::Rotation::RotZ(pImpl->baseOrientationOffsetRPY.getVal(0)).inverse() * iDynTree::Rotation::RotZ(baseTransformSolutionRPY.getVal(0)));
+
     // Expose IK solution for IHumanState
     {
         std::lock_guard<std::mutex> lock(pImpl->mutex);
@@ -1162,15 +1318,15 @@ void HumanStateProvider::run()
             pImpl->solution.jointVelocities[i] = pImpl->jointVelocitiesSolution.getVal(i);
         }
 
-        pImpl->solution.basePosition = {pImpl->baseTransformSolution.getPosition().getVal(0),
-                                        pImpl->baseTransformSolution.getPosition().getVal(1),
-                                        pImpl->baseTransformSolution.getPosition().getVal(2)};
+        pImpl->solution.basePosition = {baseTrasfromSolutionAfterOffset.getPosition().getVal(0),
+                                        baseTrasfromSolutionAfterOffset.getPosition().getVal(1),
+                                        baseTrasfromSolutionAfterOffset.getPosition().getVal(2)};
 
         pImpl->solution.baseOrientation = {
-            pImpl->baseTransformSolution.getRotation().asQuaternion().getVal(0),
-            pImpl->baseTransformSolution.getRotation().asQuaternion().getVal(1),
-            pImpl->baseTransformSolution.getRotation().asQuaternion().getVal(2),
-            pImpl->baseTransformSolution.getRotation().asQuaternion().getVal(3)};
+            baseTrasfromSolutionAfterOffset.getRotation().asQuaternion().getVal(0),
+            baseTrasfromSolutionAfterOffset.getRotation().asQuaternion().getVal(1),
+            baseTrasfromSolutionAfterOffset.getRotation().asQuaternion().getVal(2),
+            baseTrasfromSolutionAfterOffset.getRotation().asQuaternion().getVal(3)};
 
         // Use measured base frame velocity
         pImpl->solution.baseVelocity = {pImpl->baseVelocitySolution.getVal(0),
@@ -1199,6 +1355,37 @@ void HumanStateProvider::run()
     //                                          pImpl->jointVelocitiesSolution,
     //                                          pImpl->baseVelocitySolution,
     //                                          pImpl->linkErrorAngularVelocities);
+
+    // Check for rpc command status and update offsets
+    if (pImpl->commandPro.cmdStatus) {
+        if (pImpl->commandPro.positionOffsetFlag.at(0) || pImpl->commandPro.positionOffsetFlag.at(1) || pImpl->commandPro.positionOffsetFlag.at(2)) {
+            for (size_t idx=0; idx<3; idx++) {
+                if (pImpl->commandPro.positionOffsetFlag.at(idx) & !pImpl->basePositionOffsetFlag.at(idx)) {
+                    pImpl->basePositionOffset.setVal(idx, pImpl->baseTransformSolution.getPosition().getVal(idx));
+                    pImpl->basePositionOffsetFlag.at(idx) = true;
+                }
+            }
+        }
+        else {
+            pImpl->basePositionOffset.zero();
+            pImpl->basePositionOffsetFlag.fill(false);
+        }
+
+        if (pImpl->commandPro.orientationOffsetFlag.at(0) || pImpl->commandPro.orientationOffsetFlag.at(1) || pImpl->commandPro.orientationOffsetFlag.at(2)) {
+            for (size_t idx=0; idx<3; idx++) {
+                if (pImpl->commandPro.orientationOffsetFlag.at(idx) & !pImpl->baseOrientationOffsetFlag.at(idx)) {
+                    pImpl->baseOrientationOffsetRPY.setVal(idx, pImpl->baseTransformSolution.getRotation().asRPY().getVal(idx));
+                    pImpl->baseOrientationOffsetFlag.at(idx) = true;
+                }
+            }
+        }
+        else {
+            pImpl->baseOrientationOffsetRPY.zero();
+            pImpl->baseOrientationOffsetFlag.fill(false);
+        }
+
+    }
+    pImpl->commandPro.cmdStatus = false;
 }
 
 bool HumanStateProvider::impl::getLinkQuantitiesFromInputData(

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -605,7 +605,14 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
     // INITIALIZE RPC PORT
     // ===================
 
-    std::string rpcPortName = "/" + DeviceName + "/rpc:i";
+    std::string rpcPortName;
+    if (!(config.check("rpcPortPrefix") && config.find("rpcPortPrefix").isString())) {
+        rpcPortName = "/" + DeviceName + "/rpc:i";
+    }
+    else {
+        rpcPortName = "/" + config.find("rpcPortPrefix").asString() + "/" + DeviceName + "/rpc:i";
+    }
+
     if (!pImpl->rpcPort.open(rpcPortName)) {
         yError() << LogPrefix << "Unable to open rpc port " << rpcPortName;
         return false;


### PR DESCRIPTION
This PR add the feature for removing position offsets (https://github.com/robotology/human-dynamics-estimation/issues/152) + configuration files for running two human state provider.

The offset is removed by sending command to an `rpc` port opened by the `HumanStateProvider` device. It is possible to remove both position and orientation offsets for one or multiple axis.