### PR TITLE
Add secondary calibration

### DIFF
--- a/.ci/build_deps.sh
+++ b/.ci/build_deps.sh
@@ -91,9 +91,8 @@ cmake --build . --config ${TRAVIS_BUILD_TYPE} --target install
 # Build and install osqp
 cd $GIT_FOLDER
 rm -rf osqp
-git clone --recursive https://github.com/robotology-dependencies/osqp.git
+git clone --recursive https://github.com/oxfordcontrol/osqp.git
 cd osqp
-git checkout fix-lf-problems
 mkdir -p build && cd build
 cmake -G"${TRAVIS_CMAKE_GENERATOR}" \
       -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE} \
@@ -106,7 +105,6 @@ cd $GIT_FOLDER
 rm -rf OsqpEigen
 git clone https://github.com/robotology/osqp-eigen.git OsqpEigen
 cd OsqpEigen
-git checkout v0.4.1
 mkdir -p build && cd build
 cmake -G"${TRAVIS_CMAKE_GENERATOR}" \
       -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE} \

--- a/conf/xml/RobotStateProvider_Atlas.xml
+++ b/conf/xml/RobotStateProvider_Atlas.xml
@@ -26,6 +26,7 @@
         <param name="rotTargetWeight">1.0</param>
         <param name="costRegularization">1.0</param>
         <param name="costTolerance">0.001</param>
+        <param name="rpcPortPrefix">Atlas</param>
         <!-- inverse velocity kinematics parameters -->
         <!-- inverseVelocityKinematicsSolver values:
         QP
@@ -36,7 +37,7 @@
         sparseCholeskyDecomposition,
         robustCholeskyDecomposition,
         sparseRobustCholeskyDecomposition -->
-        <param name='inverseVelocityKinematicsSolver'>QP</param>
+        <param name='inverseVelocityKinematicsSolver'>sparseRobustCholeskyDecomposition</param>
         <param name="linVelTargetWeight">0.0</param>
         <param name="angVelTargetWeight">1.0</param>
         <!-- integration based IK parameters -->

--- a/conf/xml/RobotStateProvider_Baxter.xml
+++ b/conf/xml/RobotStateProvider_Baxter.xml
@@ -26,6 +26,7 @@
         <param name="rotTargetWeight">1.0</param>
         <param name="costRegularization">1.0</param>
         <param name="costTolerance">0.001</param>
+        <param name="rpcPortPrefix">Baxter</param>
         <!-- inverse velocity kinematics parameters -->
         <!-- inverseVelocityKinematicsSolver values:
         QP

--- a/conf/xml/RobotStateProvider_Human.xml
+++ b/conf/xml/RobotStateProvider_Human.xml
@@ -26,6 +26,7 @@
         <param name="rotTargetWeight">1.0</param>
         <param name="costRegularization">0.000001</param>
         <param name="costTolerance">0.001</param>
+        <param name="rpcPortPrefix">Human</param>
         <!-- inverse velocity kinematics parameters -->
         <!-- inverseVelocityKinematicsSolver values:
         QP
@@ -36,7 +37,7 @@
         sparseCholeskyDecomposition,
         robustCholeskyDecomposition,
         sparseRobustCholeskyDecomposition -->
-        <param name='inverseVelocityKinematicsSolver'>QP</param>
+        <param name='inverseVelocityKinematicsSolver'>sparseRobustCholeskyDecomposition</param>
         <param name="linVelTargetWeight">0.0</param>
         <param name="angVelTargetWeight">1.0</param>
         <!-- integration based IK parameters -->

--- a/conf/xml/RobotStateProvider_Nao.xml
+++ b/conf/xml/RobotStateProvider_Nao.xml
@@ -26,6 +26,7 @@
         <param name="rotTargetWeight">1.0</param>
         <param name="costRegularization">1.0</param>
         <param name="costTolerance">0.001</param>
+        <param name="rpcPortPrefix">Nao</param>
         <!-- inverse velocity kinematics parameters -->
         <!-- inverseVelocityKinematicsSolver values:
         QP

--- a/conf/xml/RobotStateProvider_Walkman.xml
+++ b/conf/xml/RobotStateProvider_Walkman.xml
@@ -26,6 +26,7 @@
         <param name="rotTargetWeight">1.0</param>
         <param name="costRegularization">1.0</param>
         <param name="costTolerance">0.001</param>
+	<param name="rpcPortPrefix">Walkman</param>
         <!-- inverse velocity kinematics parameters -->
         <!-- inverseVelocityKinematicsSolver values:
         QP
@@ -36,7 +37,7 @@
         sparseCholeskyDecomposition,
         robustCholeskyDecomposition,
         sparseRobustCholeskyDecomposition -->
-        <param name='inverseVelocityKinematicsSolver'>QP</param>
+        <param name='inverseVelocityKinematicsSolver'>sparseRobustCholeskyDecomposition</param>
         <param name="linVelTargetWeight">0.0</param>
         <param name="angVelTargetWeight">1.0</param>
         <!-- integration based IK parameters -->
@@ -131,7 +132,7 @@
         <param name="baseTFName">/Walkman/base_link</param>
         <param name="humanJointsTopic">/Walkman/joint_states</param>
 	<param name="portprefix">walkman</param>
-	<param name="basePositionOffset">(0.0 5.0 0.0)</param>
+	<param name="basePositionOffset">(0.0 8.0 0.0)</param>
 	<!--param name="baseOrientationOffset">(0.7071068 0.0 0.0 0.7071068)</param-->
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/conf/xml/RobotStateProvider_iCub.xml
+++ b/conf/xml/RobotStateProvider_iCub.xml
@@ -26,6 +26,7 @@
         <param name="rotTargetWeight">1.0</param>
         <param name="costRegularization">1.0</param>
         <param name="costTolerance">0.001</param>
+        <param name="rpcPortPrefix">iCub</param>
         <!-- inverse velocity kinematics parameters -->
         <!-- inverseVelocityKinematicsSolver values:
         QP


### PR DESCRIPTION
Adding secondary calibration as described in https://github.com/robotology/human-dynamics-estimation/issues/158.

The PR still need to be cleaned, and the rpc interfaces changed accordingly to what described in https://github.com/robotology/human-dynamics-estimation/issues/159 (unfortunately this is a duplicate of the same changes done in the feature branch, merging the branch will need to be handled correctly)