### PR TITLE
Add matio logging to HumanDataCollector device

### DIFF
--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -426,6 +426,7 @@
         <param name="portPrefix">Human</param>
         <param name="matioLogger">true</param>
         <param name="matLogDirectory">testData</param>
+        <param name="matLogFileName">matLogFile</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStateProvideLabel">HumanStateProvider</elem>

--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -422,7 +422,7 @@
     </device>
 
     <device type="human_data_collector" name="HumanDataCollector">
-        <param name="period">0.1</param>
+        <param name="period">0.02</param>
         <param name="portPrefix">Human</param>
         <param name="matioLogger">true</param>
         <param name="matLogDirectory">testData</param>

--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -424,6 +424,8 @@
     <device type="human_data_collector" name="HumanDataCollector">
         <param name="period">0.1</param>
         <param name="portPrefix">Human</param>
+        <param name="matioLogger">true</param>
+        <param name="matLogDirectory">testData</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="HumanStateProvideLabel">HumanStateProvider</elem>

--- a/devices/HumanControlBoard/CMakeLists.txt
+++ b/devices/HumanControlBoard/CMakeLists.txt
@@ -24,7 +24,7 @@ add_definitions(-D_USE_MATH_DEFINES)
 target_link_libraries(HumanControlBoard PUBLIC
     IHumanState
     IHumanDynamics
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_init
     iDynTree::idyntree-model

--- a/devices/HumanControlBoard/HumanControlBoard.cpp
+++ b/devices/HumanControlBoard/HumanControlBoard.cpp
@@ -85,7 +85,7 @@ bool HumanControlBoard::open(yarp::os::Searchable& config)
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================
 
-    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asDouble();
+    const double period = config.check("period", yarp::os::Value(DefaultPeriod)).asDouble();
     const std::string urdfFileName = config.find("urdf").asString();
 
     // ==========================

--- a/devices/HumanDataCollector/CMakeLists.txt
+++ b/devices/HumanDataCollector/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(HumanDataCollector PUBLIC
     UtilityLibrary
     matio
     stdc++fs
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_init)
 

--- a/devices/HumanDataCollector/CMakeLists.txt
+++ b/devices/HumanDataCollector/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(HumanDataCollector PUBLIC
     IHumanDynamics
     UtilityLibrary
     matio
+    stdc++fs
     YARP::YARP_OS
     YARP::YARP_dev
     YARP::YARP_init)

--- a/devices/HumanDataCollector/CMakeLists.txt
+++ b/devices/HumanDataCollector/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(HumanDataCollector PUBLIC
     IHumanWrench
     IHumanDynamics
     UtilityLibrary
+    matio
     YARP::YARP_OS
     YARP::YARP_dev
     YARP::YARP_init)

--- a/devices/HumanDataCollector/HumanDataCollector.cpp
+++ b/devices/HumanDataCollector/HumanDataCollector.cpp
@@ -27,12 +27,23 @@
 #include <algorithm>
 #include <utility>
 #include <unordered_map>
+#include <functional>
 
 const std::string DeviceName = "HumanDataCollector";
 const std::string LogPrefix = DeviceName + " :";
 constexpr double DefaultPeriod = 0.01;
 
 using namespace hde::devices;
+
+// Inline functions for matio variables destructor calls
+auto matVarFree = [](matvar_t* matvar) -> void {Mat_VarFree(matvar);};
+
+auto matFileClose = [](mat_t* mat) -> void {Mat_Close(mat);
+                                            yInfo() << LogPrefix << "Closed mat file";};
+
+// Unique pointer wrapping of matio variables
+template <typename T>
+using MatVarPtr = std::unique_ptr<T, std::function<void(T*)>>;
 
 void writeVectorOfStringToMatCell(const std::string& name, const std::vector<std::string>& strings, mat_t* matFile)
 {
@@ -42,12 +53,11 @@ void writeVectorOfStringToMatCell(const std::string& name, const std::vector<std
     }
 
     size_t dims[2] = {strings.size(), 1};
-    matvar_t* matCellArray = Mat_VarCreate(name.c_str(), MAT_C_CELL, MAT_T_CELL, 2, dims, nullptr, 0);
+    MatVarPtr<matvar_t> matCellArray(Mat_VarCreate(name.c_str(), MAT_C_CELL, MAT_T_CELL, 2, dims, nullptr, 0),
+                                     matVarFree);
 
     if (matCellArray == nullptr) {
         yError() << LogPrefix << "Failed to create mat cell array " << name;
-        Mat_VarFree(matCellArray);
-        Mat_Close(matFile);
         return;
     }
 
@@ -61,16 +71,13 @@ void writeVectorOfStringToMatCell(const std::string& name, const std::vector<std
         if (matCellElement == nullptr) {
             yError() << LogPrefix << "Failed to create mat cell element";
             Mat_VarFree(matCellElement);
-            Mat_VarFree(matCellArray);
-            Mat_Close(matFile);
             return;
         }
 
-        Mat_VarSetCell(matCellArray, i, matCellElement);
+        Mat_VarSetCell(matCellArray.get(), i, matCellElement);
     }
 
-    Mat_VarWrite(matFile, matCellArray, MAT_COMPRESSION_NONE);
-    Mat_VarFree(matCellArray);
+    Mat_VarWrite(matFile, matCellArray.get(), MAT_COMPRESSION_NONE);
 }
 
 void writeVectorOfVectorDoubleToMatStruct(const std::unordered_map<std::string, std::vector<std::vector<double>>>& humanData, mat_t* matFile) {
@@ -92,12 +99,11 @@ void writeVectorOfVectorDoubleToMatStruct(const std::unordered_map<std::string, 
     size_t matDataStructDims[2] = {1, 1};
 
     // Initialize mat struct variable
-     matvar_t *matDataStruct = Mat_VarCreateStruct("data", 1, matDataStructDims, fieldNames.data(), matStructFieldNamesVec.size());
+     MatVarPtr<matvar_t> matDataStruct(Mat_VarCreateStruct("data", 1, matDataStructDims, fieldNames.data(), matStructFieldNamesVec.size()),
+                                       matVarFree);
 
     if (matDataStruct == nullptr) {
         yError() << LogPrefix << "Failed to initialize matio struct variable";
-        Mat_VarFree(matDataStruct);
-        Mat_Close(matFile);
         return;
     }
 
@@ -124,19 +130,16 @@ void writeVectorOfVectorDoubleToMatStruct(const std::unordered_map<std::string, 
         if (mat2darray == nullptr) {
             yError() << LogPrefix << "Failed to create a 2d numeric array to store in the mat struct variable";
             Mat_VarFree(mat2darray);
-            Mat_VarFree(matDataStruct);
-            Mat_Close(matFile);
             return;
         }
 
         // Set the 2d numeric array to the mat struct variable
-        Mat_VarSetStructFieldByName(matDataStruct, pair.first.c_str(), 0, mat2darray);
+        Mat_VarSetStructFieldByName(matDataStruct.get(), pair.first.c_str(), 0, mat2darray);
 
     }
 
     // Write mat struct to mat file before closing
-    Mat_VarWrite(matFile, matDataStruct, MAT_COMPRESSION_NONE);
-    Mat_VarFree(matDataStruct);
+    Mat_VarWrite(matFile, matDataStruct.get(), MAT_COMPRESSION_NONE);
 
     yDebug() << LogPrefix << "Finished writing mat struct to the mat file";
 
@@ -244,7 +247,7 @@ public:
     const std::experimental::filesystem::path originalWorkingDirectory = std::experimental::filesystem::current_path();
     std::string matLogDirectory = "";
     std::string matLogFileName; //TODO: Improve file handling for multiple file logging
-    mat_t *matFilePtr = nullptr;
+    MatVarPtr<mat_t> matFilePtr = nullptr;
 
     // Time Buffers
     std::chrono::system_clock::time_point startTime;
@@ -472,7 +475,7 @@ void HumanDataCollector::run()
 
             // TODO: Handle multiple files
             std::string matLogFileFullPathName = pImpl->matLogDirectory + pImpl->matLogFileName;
-            pImpl->matFilePtr = Mat_CreateVer(matLogFileFullPathName.c_str(), nullptr, MAT_FT_MAT73);
+            pImpl->matFilePtr = {Mat_CreateVer(matLogFileFullPathName.c_str(), nullptr, MAT_FT_MAT73), matFileClose};
 
             if (pImpl->matFilePtr == nullptr) {
                 yError() << LogPrefix << "Failed to create " << pImpl->matLogFileName << " MAT file for logging";
@@ -861,10 +864,10 @@ bool HumanDataCollector::detach()
     if (pImpl->matioLogger) {
 
         // Set the string variables elements as cell arrays to mat cell variables
-        writeVectorOfStringToMatCell("stateJointNames", pImpl->humanDataStruct.stateJointNames, pImpl->matFilePtr);
-        writeVectorOfStringToMatCell("wrenchMeasurementSourceNames", pImpl->humanDataStruct.wrenchMeasurementSourceNames, pImpl->matFilePtr);
-        writeVectorOfStringToMatCell("wrenchEstimateSourceNames", pImpl->humanDataStruct.wrenchEstimateSourceNames, pImpl->matFilePtr);
-        writeVectorOfStringToMatCell("dynamicsJointNames", pImpl->humanDataStruct.dynamicsJointNames, pImpl->matFilePtr);
+        writeVectorOfStringToMatCell("stateJointNames", pImpl->humanDataStruct.stateJointNames, pImpl->matFilePtr.get());
+        writeVectorOfStringToMatCell("wrenchMeasurementSourceNames", pImpl->humanDataStruct.wrenchMeasurementSourceNames, pImpl->matFilePtr.get());
+        writeVectorOfStringToMatCell("wrenchEstimateSourceNames", pImpl->humanDataStruct.wrenchEstimateSourceNames, pImpl->matFilePtr.get());
+        writeVectorOfStringToMatCell("dynamicsJointNames", pImpl->humanDataStruct.dynamicsJointNames, pImpl->matFilePtr.get());
 
         // Correct the time values stored in the time vector to zero start value
         std::transform( pImpl->humanDataStruct.time.begin(), pImpl->humanDataStruct.time.end(), pImpl->humanDataStruct.time.begin(),
@@ -884,14 +887,7 @@ bool HumanDataCollector::detach()
         }
 
         // Set human data to mat struct
-        writeVectorOfVectorDoubleToMatStruct(pImpl->humanDataStruct.data, pImpl->matFilePtr);
-
-        // Close the mat file
-        Mat_Close(pImpl->matFilePtr);
-
-        yDebug() << LogPrefix << "Closed mat file";
-
-        pImpl->matFilePtr = nullptr;
+        writeVectorOfVectorDoubleToMatStruct(pImpl->humanDataStruct.data, pImpl->matFilePtr.get());
 
     }
 

--- a/devices/HumanDataCollector/HumanDataCollector.cpp
+++ b/devices/HumanDataCollector/HumanDataCollector.cpp
@@ -285,7 +285,8 @@ bool HumanDataCollector::open(yarp::os::Searchable &config) {
     pImpl->matioLogger = config.check("matioLogger", yarp::os::Value(false)).asBool();
 
     if (pImpl->matioLogger) {
-        pImpl->matLogDirectory =  pImpl->originalWorkingDirectory.string() + "/" + config.check("matLogDirectory", yarp::os::Value("matLogDirectory")).asString() + "/";
+        pImpl->matLogDirectory =  pImpl->originalWorkingDirectory.string() + "/" +
+                                  config.check("matLogDirectory", yarp::os::Value("matLogDirectory")).asString() + "/";
 
         struct stat info;
 
@@ -868,7 +869,8 @@ bool HumanDataCollector::detach()
         writeVectorOfStringToMatCell("dynamicsJointNames", pImpl->humanDataStruct.dynamicsJointNames, pImpl->matFilePtr);
 
         // Correct the time values stored in the time vector to zero start value
-        std::transform( pImpl->humanDataStruct.time.begin(), pImpl->humanDataStruct.time.end(), pImpl->humanDataStruct.time.begin(), std::bind2nd( std::plus<long>(), - pImpl->humanDataStruct.time.at(0) ) );
+        std::transform( pImpl->humanDataStruct.time.begin(), pImpl->humanDataStruct.time.end(), pImpl->humanDataStruct.time.begin(),
+                        std::bind2nd( std::plus<long>(), - pImpl->humanDataStruct.time.at(0) ) );
 
         // Create an array with time elements
         long time[pImpl->humanDataStruct.time.size()];

--- a/devices/HumanDataCollector/HumanDataCollector.cpp
+++ b/devices/HumanDataCollector/HumanDataCollector.cpp
@@ -620,18 +620,16 @@ void HumanDataCollector::run()
                 pImpl->humanDataStruct.stateJointNames = pImpl->stateJointNames;
             }
 
+            pImpl->humanDataStruct.data["basePose"].push_back(pImpl->basePoseVec);
+            pImpl->humanDataStruct.data["baseVelocity"].push_back(pImpl->baseVeclocityVec);
 
-            pImpl->humanDataStruct.data.at("basePose").push_back(pImpl->basePoseVec);
-            pImpl->humanDataStruct.data.at("baseVelocity").push_back(pImpl->baseVeclocityVec);
+            pImpl->humanDataStruct.data["comPosition"].push_back(pImpl->comPositionVec);
+            pImpl->humanDataStruct.data["comVelocity"].push_back(pImpl->comVelocityVec);
+            pImpl->humanDataStruct.data["comProperAccelerationInBaseFrame"].push_back(pImpl->comProperAccInBaseFrameVec);
+            pImpl->humanDataStruct.data["comProperAccelerationInWorldFrame"].push_back(pImpl->comProperAccInWorldFrameVec);
 
-            pImpl->humanDataStruct.data.at("comPosition").push_back(pImpl->comPositionVec);
-            pImpl->humanDataStruct.data.at("comVelocity").push_back(pImpl->comVelocityVec);
-            pImpl->humanDataStruct.data.at("comProperAccelerationInBaseFrame").push_back(pImpl->comProperAccInBaseFrameVec);
-            pImpl->humanDataStruct.data.at("comProperAccelerationInWorldFrame").push_back(pImpl->comProperAccInWorldFrameVec);
-
-            pImpl->humanDataStruct.data.at("jointPositions").push_back(pImpl->jointPositionsVec);
-            pImpl->humanDataStruct.data.at("jointVelocities").push_back(pImpl->jointVelocitiesVec);
-
+            pImpl->humanDataStruct.data["jointPositions"].push_back(pImpl->jointPositionsVec);
+            pImpl->humanDataStruct.data["jointVelocities"].push_back(pImpl->jointVelocitiesVec);
 
         }
 
@@ -881,7 +879,7 @@ bool HumanDataCollector::detach()
             //TODO: Double check the long double conversion handling
             std::vector<double> count;
             count.push_back(timeCount);
-            pImpl->humanDataStruct.data.at("time").push_back(count);
+            pImpl->humanDataStruct.data["time"].push_back(count);
 
         }
 

--- a/devices/HumanDataCollector/HumanDataCollector.cpp
+++ b/devices/HumanDataCollector/HumanDataCollector.cpp
@@ -16,6 +16,8 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/sig/Vector.h>
 
+#include "matio.h"
+
 const std::string DeviceName = "HumanDataCollector";
 const std::string LogPrefix = DeviceName + " :";
 constexpr double DefaultPeriod = 0.01;

--- a/devices/HumanDataCollector/HumanDataCollector.cpp
+++ b/devices/HumanDataCollector/HumanDataCollector.cpp
@@ -147,7 +147,6 @@ class HumanDataCollector::impl
 {
 public:
 
-    double period;
     std::string portPrefix;
     bool firstData = true;
 
@@ -277,7 +276,7 @@ bool HumanDataCollector::open(yarp::os::Searchable &config) {
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================
 
-    double period = config.check("period", yarp::os::Value(0.01)).asFloat64();
+    const double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
     pImpl->portPrefix = "/" + config.check("portPrefix", yarp::os::Value("HDE")).asString() + "/";
     pImpl->matioLogger = config.check("matioLogger", yarp::os::Value(false)).asBool();
 
@@ -304,8 +303,8 @@ bool HumanDataCollector::open(yarp::os::Searchable &config) {
     yInfo() << LogPrefix << "*** matLogDirectory           :" << pImpl->matLogDirectory;
     yInfo() << LogPrefix << "*** ===========================";
 
-    // Set period
-    setPeriod(pImpl->period);
+    // Set periodicThread period
+    this->setPeriod(period);
 
     return true;
 }

--- a/devices/HumanDataCollector/HumanDataCollector.cpp
+++ b/devices/HumanDataCollector/HumanDataCollector.cpp
@@ -34,7 +34,7 @@ constexpr double DefaultPeriod = 0.01;
 
 using namespace hde::devices;
 
-void writeVectorOfStringToMatCell(const std::string name, const std::vector<std::string>& strings, mat_t* matFile)
+void writeVectorOfStringToMatCell(const std::string& name, const std::vector<std::string>& strings, mat_t* matFile)
 {
     if (strings.empty()) {
         yError() << LogPrefix << "Passed string is empty";

--- a/devices/HumanDataCollector/HumanDataCollector.cpp
+++ b/devices/HumanDataCollector/HumanDataCollector.cpp
@@ -75,8 +75,6 @@ void writeVectorOfStringToMatCell(const std::string name, const std::vector<std:
 
 void writeVectorOfVectorDoubleToMatStruct(const std::unordered_map<std::string, std::vector<std::vector<double>>>& humanData, mat_t* matFile) {
 
-    yInfo() << LogPrefix << "Inside writeVectorOfVectorDoubleToMatStruct";
-
     // Set the mat struct field names
     std::vector<std::string> matStructFieldNamesVec;
 
@@ -104,31 +102,24 @@ void writeVectorOfVectorDoubleToMatStruct(const std::unordered_map<std::string, 
     }
 
     // Iterate over human data and set to numeric arrays of mat struct
-    // TODO: Seg fault occurs during this loop - to be fixed
     for (const std::pair<std::string, std::vector<std::vector<double>>> pair : humanData) {
 
         const size_t rows = pair.second.size();
         const size_t cols = pair.second.at(0).size(); // Assuming same number of elements in the vector
-        yInfo() << LogPrefix << "map variable " << pair.first.c_str() << " rows : " << rows << " cols : " << cols;
-        double array2d[rows][cols];
 
-        yInfo() << LogPrefix << "Size of " << pair.first.c_str() << " array2d " << sizeof (array2d);
+        std::vector<double> values;
 
+        // TODO: Check if this can be improved through STL
         for (size_t r = 0; r < rows; r++) {
             for (size_t c = 0; c < cols; c++) {
-                array2d[r][c] = pair.second[r].at(c);
+                values.push_back(pair.second[r].at(c));
             }
         }
 
-//        ////
-//        std::vector<double> row = pair.second[0];
-//        double* data = row.data();
-//        ////
-
         // Create a mat variable for 2d numeric array
-        // NOTE: rows and cols are reversed from the regular array
+        // NOTE: rows and cols are reversed from the regular array because mat variables are column major
         size_t dims[2] = {cols, rows};
-        matvar_t *mat2darray = Mat_VarCreate(pair.first.c_str(), MAT_C_DOUBLE, MAT_T_DOUBLE, 2, dims, &array2d, 0);
+        matvar_t *mat2darray = Mat_VarCreate(pair.first.c_str(), MAT_C_DOUBLE, MAT_T_DOUBLE, 2, dims, values.data(), 0);
 
         if (mat2darray == nullptr) {
             yError() << LogPrefix << "Failed to create a 2d numeric array to store in the mat struct variable";
@@ -147,7 +138,7 @@ void writeVectorOfVectorDoubleToMatStruct(const std::unordered_map<std::string, 
     Mat_VarWrite(matFile, matDataStruct, MAT_COMPRESSION_NONE);
     Mat_VarFree(matDataStruct);
 
-    yInfo() << LogPrefix << "Finished writing mat struct to the mat file";
+    yDebug() << LogPrefix << "Finished writing mat struct to the mat file";
 
 }
 
@@ -891,7 +882,7 @@ bool HumanDataCollector::detach()
         // Close the mat file
         Mat_Close(pImpl->matFilePtr);
 
-        yInfo() << LogPrefix << "Closed mat file";
+        yDebug() << LogPrefix << "Closed mat file";
 
         pImpl->matFilePtr = nullptr;
 

--- a/devices/HumanDataCollector/HumanDataCollector.cpp
+++ b/devices/HumanDataCollector/HumanDataCollector.cpp
@@ -243,7 +243,7 @@ public:
     bool matioLogger = false;
     const std::experimental::filesystem::path originalWorkingDirectory = std::experimental::filesystem::current_path();
     std::string matLogDirectory = "";
-    std::string matLogFileName = "matLogFile.mat"; //TODO: Improve file handling for multiple file logging
+    std::string matLogFileName; //TODO: Improve file handling for multiple file logging
     mat_t *matFilePtr = nullptr;
 
     // Time Buffers
@@ -272,6 +272,10 @@ bool HumanDataCollector::open(yarp::os::Searchable &config) {
         yInfo() << LogPrefix << "Using default portPrefix HDE ";
     }
 
+    if (!(config.check("matLogFileName") && config.find("matLogFileName").isString())) {
+        yInfo() << LogPrefix << "Using default file name matLogFile.mat";
+    }
+
     // ===============================
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================
@@ -294,6 +298,9 @@ bool HumanDataCollector::open(yarp::os::Searchable &config) {
         std::experimental::filesystem::current_path(pImpl->matLogDirectory);
     }
 
+    // Get matLogFileName value from config
+    pImpl->matLogFileName = config.check("matLogFileName", yarp::os::Value("matLogFile")).asString() + ".mat";
+
     //TODO: Define rpc to reset the data dump or restarting the visualization??
 
     yInfo() << LogPrefix << "*** ===========================";
@@ -301,6 +308,7 @@ bool HumanDataCollector::open(yarp::os::Searchable &config) {
     yInfo() << LogPrefix << "*** portPrefix                :" << pImpl->portPrefix;
     yInfo() << LogPrefix << "*** matioLogger               :" << pImpl->matioLogger;
     yInfo() << LogPrefix << "*** matLogDirectory           :" << pImpl->matLogDirectory;
+    yInfo() << LogPrefix << "*** matLogFileName            :" << pImpl->matLogFileName;
     yInfo() << LogPrefix << "*** ===========================";
 
     // Set periodicThread period

--- a/devices/HumanDynamicsEstimator/CMakeLists.txt
+++ b/devices/HumanDynamicsEstimator/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(HumanDynamicsEstimator PUBLIC
     IHumanState
     IHumanWrench
     IHumanDynamics
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_sig
     YARP::YARP_init

--- a/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.cpp
+++ b/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.cpp
@@ -803,8 +803,6 @@ static bool parsePriorsGroup(const yarp::os::Bottle& priorsGroup,
             }
             else
             {
-                yInfo() << LogPrefix << "Found cov_task1_measurements for sensor"
-                        << berdySensorTypeString << ", it will be used in second task";
                 if (!getTripletsFromPriorGroup(
                         priorsGroup, covTask1MeasurementOptionPrefix, berdySensorTypeString, triplets, berdySensor)) {
                     yError() << LogPrefix << "Failed to get triplets for sensor"
@@ -1222,11 +1220,14 @@ bool HumanDynamicsEstimator::open(yarp::os::Searchable& config)
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================
 
-    double period = config.find("period").asFloat64();
-    std::string urdfFileName = config.find("urdf").asString();
-    std::string baseLink = config.find("baseLink").asString();
+    const double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
+    const std::string urdfFileName = config.find("urdf").asString();
+    const std::string baseLink = config.find("baseLink").asString();
     int number_of_wrench_sensors = config.find("number_of_wrench_sensors").asInt();
     yarp::os::Bottle* linkNames = config.find("wrench_sensors_link_name").asList();
+
+    // Set periodicThread period
+    this->setPeriod(period);
 
     // Configuration option for removing the offset
     pImpl->removeOffsetOption = config.check("removeOffsetOption",yarp::os::Value("model")).asString();
@@ -1428,11 +1429,6 @@ bool HumanDynamicsEstimator::open(yarp::os::Searchable& config)
     size_t task1_numberOfDynVariables = pImpl->berdyData.helper.getNrOfDynamicVariables(true);
     size_t task1_numberOfDynEquations = pImpl->berdyData.helper.getNrOfDynamicEquations(true);
     size_t task1_numberOfMeasurements = pImpl->berdyData.helper.getNrOfSensorsMeasurements(true);
-
-    // Debug info
-    yInfo() << LogPrefix << "Task1 number of dynamic variables : " << task1_numberOfDynVariables;
-    yInfo() << LogPrefix << "Task1 number of dynamic equations : " << task1_numberOfDynEquations;
-    yInfo() << LogPrefix << "Task1 number of measurements : " << task1_numberOfMeasurements;
 
     // Set measurements size and initialize to zero
     pImpl->berdyData.buffers.measurements.resize(numberOfMeasurements);

--- a/devices/HumanStateProvider/CMakeLists.txt
+++ b/devices/HumanStateProvider/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(HumanStateProvider PUBLIC
 
 target_link_libraries(HumanStateProvider PUBLIC
     IHumanState
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_init
     IWear::IWear

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -671,6 +671,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
     pImpl->floatingBaseFrame.wearable = floatingBaseFrameList->get(1).asString();
     pImpl->period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
 
+    // Set periodicThread period
     setPeriod(pImpl->period);
 
     // Parse linksGroup parameters

--- a/devices/HumanWrenchProvider/CMakeLists.txt
+++ b/devices/HumanWrenchProvider/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(HumanWrenchProvider PUBLIC
 target_link_libraries(HumanWrenchProvider PUBLIC
     IHumanState
     IHumanWrench
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_sig
     YARP::YARP_init

--- a/devices/HumanWrenchProvider/HumanWrenchProvider.cpp
+++ b/devices/HumanWrenchProvider/HumanWrenchProvider.cpp
@@ -149,6 +149,10 @@ bool HumanWrenchProvider::open(yarp::os::Searchable& config)
         yInfo() << LogPrefix << "Using default period:" << DefaultPeriod << "s";
     }
 
+    // Set periodicThread period
+    const double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
+    this->setPeriod(period);
+
     if (!(config.check("pHRIScenario") && config.find("pHRIScenario").isBool())) {
         yError() << LogPrefix << "Option 'pHRIScenario' not found or not a valid bool";
         return false;

--- a/devices/RobotPositionController/CMakeLists.txt
+++ b/devices/RobotPositionController/CMakeLists.txt
@@ -24,7 +24,7 @@ add_definitions(-D_USE_MATH_DEFINES)
 
 target_link_libraries(RobotPositionController PUBLIC
     IHumanState
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_init
     iDynTree::idyntree-model

--- a/devices/RobotPositionController/RobotPositionController.cpp
+++ b/devices/RobotPositionController/RobotPositionController.cpp
@@ -125,7 +125,7 @@ bool RobotPositionController::open(yarp::os::Searchable& config)
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================
 
-    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asDouble();
+    const double period = config.check("period", yarp::os::Value(DefaultPeriod)).asDouble();
     pImpl->controlMode = config.find("controlMode").asString();
     pImpl->refSpeed = config.find("refSpeed").asDouble();
     pImpl->samplingTime = config.find("samplingTime").asDouble();
@@ -144,6 +144,9 @@ bool RobotPositionController::open(yarp::os::Searchable& config)
     yInfo() << LogPrefix << "*** Remote prefix          :" << remotePrefix;
     yInfo() << LogPrefix << "*** Local prefix           :" << localPrefix;
     yInfo() << LogPrefix << "*** ========================";
+
+    // Set periodicThread period
+    setPeriod(period);
 
     // ====================================
     // INITIALIZE THE REMOTE CONTROL BOARDS

--- a/publishers/HumanDynamicsPublisher/CMakeLists.txt
+++ b/publishers/HumanDynamicsPublisher/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(HumanDynamicsPublisher PUBLIC
 
 target_link_libraries(HumanDynamicsPublisher PUBLIC
     IHumanDynamics
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_init
     YARP::YARP_rosmsg)

--- a/publishers/HumanDynamicsPublisher/HumanDynamicsPublisher.cpp
+++ b/publishers/HumanDynamicsPublisher/HumanDynamicsPublisher.cpp
@@ -117,7 +117,9 @@ bool HumanDynamicsPublisher::open(yarp::os::Searchable& config)
     // READ PARAMETERS
     // ===============
 
-    double period = config.find("period").asFloat64();
+    // Set periodicTheard period
+    const double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
+    setPeriod(period);
 
     yarp::os::Bottle* listOfLinkNames = config.find("parentLinkNames").asList();
     yarp::os::Bottle* listOfJointNames = config.find("sphericalJointNames").asList();
@@ -173,7 +175,6 @@ bool HumanDynamicsPublisher::open(yarp::os::Searchable& config)
         pImpl->modelEffortData.push_back(jointEffortData);
     }
 
-    setPeriod(period);
     return true;
 }
 

--- a/publishers/HumanRobotPosePublisher/CMakeLists.txt
+++ b/publishers/HumanRobotPosePublisher/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(HumanRobotPosePublisher PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 target_link_libraries(HumanRobotPosePublisher PRIVATE
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_init
     YARP::YARP_math

--- a/publishers/HumanStatePublisher/CMakeLists.txt
+++ b/publishers/HumanStatePublisher/CMakeLists.txt
@@ -22,7 +22,7 @@ target_include_directories(HumanStatePublisher PUBLIC
 target_link_libraries(HumanStatePublisher PUBLIC
     IHumanState
     HumanROSMsgs
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_init
     YARP::YARP_rosmsg

--- a/publishers/HumanStatePublisher/HumanStatePublisher.cpp
+++ b/publishers/HumanStatePublisher/HumanStatePublisher.cpp
@@ -198,10 +198,7 @@ bool HumanStatePublisher::open(yarp::os::Searchable& config)
     // READ PARAMETERS
     // ===============
 
-    float period = DefaultPeriod;
-    if (!useDefaultPeriod) {
-        period = config.find("period").asFloat64();
-    }
+    const double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
 
     pImpl->baseTFName = config.find("baseTFName").asString(); // e.g. /Human/Pelvis
     std::string humanJointsTopicName = config.find("humanJointsTopic").asString();

--- a/publishers/XsensTFPublisher/CMakeLists.txt
+++ b/publishers/XsensTFPublisher/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(XsensTFPublisher PRIVATE
 target_link_libraries(XsensTFPublisher PRIVATE
     HumanROSMsgs
     IWear::IWear
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_init
     YARP::YARP_math

--- a/wrappers/HumanDynamicsWrapper/CMakeLists.txt
+++ b/wrappers/HumanDynamicsWrapper/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(HumanDynamicsWrapper PUBLIC
 target_link_libraries(HumanDynamicsWrapper PUBLIC
     IHumanDynamics
     HumanDynamicsMsg
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_init)
 

--- a/wrappers/HumanDynamicsWrapper/HumanDynamicsWrapper.cpp
+++ b/wrappers/HumanDynamicsWrapper/HumanDynamicsWrapper.cpp
@@ -57,7 +57,7 @@ bool HumanDynamicsWrapper::open(yarp::os::Searchable& config)
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================
 
-    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asDouble();
+    const double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
     std::string outputPortName = config.find("outputPort").asString();
 
     // =============

--- a/wrappers/HumanDynamicsWrapper/HumanDynamicsWrapper.cpp
+++ b/wrappers/HumanDynamicsWrapper/HumanDynamicsWrapper.cpp
@@ -8,7 +8,7 @@
 
 #include "HumanDynamicsWrapper.h"
 #include "IHumanDynamics.h"
-#include "thrift/HumanDynamics.h"
+#include <HumanDynamicsEstimation/HumanDynamics.h>
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/LogStream.h>

--- a/wrappers/HumanStateWrapper/CMakeLists.txt
+++ b/wrappers/HumanStateWrapper/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(HumanStateWrapper PUBLIC
 target_link_libraries(HumanStateWrapper PUBLIC
     IHumanState
     HumanStateMsg
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_dev
     YARP::YARP_init)
 

--- a/wrappers/HumanStateWrapper/HumanStateWrapper.cpp
+++ b/wrappers/HumanStateWrapper/HumanStateWrapper.cpp
@@ -8,7 +8,7 @@
 
 #include "HumanStateWrapper.h"
 #include "IHumanState.h"
-#include "thrift/HumanState.h"
+#include <HumanDynamicsEstimation/HumanState.h>
 
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/LogStream.h>

--- a/wrappers/HumanStateWrapper/HumanStateWrapper.cpp
+++ b/wrappers/HumanStateWrapper/HumanStateWrapper.cpp
@@ -53,7 +53,7 @@ bool HumanStateWrapper::open(yarp::os::Searchable& config)
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================
 
-    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asDouble();
+    const double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
     std::string outputPortName = config.find("outputPort").asString();
 
     // =============


### PR DESCRIPTION
#### Major Features

This PR mainly adds the feature of logging human data from `HumanDataCollector` device https://github.com/robotology/human-dynamics-estimation/pull/178 to a `.mat` file using [matio library](https://github.com/tbeu/matio) as discussed in https://github.com/robotology/human-dynamics-estimation/issues/179. 


#### Minor Fixes
- Update `YARP_OS` to `YARP_os` in cmake files to remove cmake warning https://github.com/robotology/human-dynamics-estimation/pull/181/commits/33c6ada4314ee078f58125593b058207e0a18369