### PR TITLE
Express net external wrench estimates of dummy source with orientation of world frame

### DIFF
--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -323,6 +323,7 @@
         <param name="removeOffsetOption">source</param>
         <param name="dynamicWrenchOffsetSD">30.0</param>
         <param name="wrenchEstimationForceLowerThreshold">10</param>
+        <param name="expressDummyWrenchEstimatesInWorldOrientation">true</param>
         <group name="PRIORS">
            <param name="mu_dyn_variables">1e-6</param>
            <param name="cov_dyn_variables">1e6</param>

--- a/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.cpp
+++ b/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.cpp
@@ -2309,7 +2309,7 @@ void HumanDynamicsEstimator::run()
                     iDynTree::Transform world_H_link = kinDynComputations.getWorldTransform(linkName);
 
                     // Set the position to zero
-                    world_H_link.setPosition(iDynTree::Position());
+                    world_H_link.setPosition(iDynTree::Position(0.0, 0.0, 0.0));
 
                     // Get extracted wrench
                     iDynTree::Wrench linkWrench = pImpl->berdyData.estimates.linkNetExternalWrenchEstimates(linkIndex);

--- a/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.cpp
+++ b/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.cpp
@@ -1027,8 +1027,8 @@ public:
     // Wrench sensor link names variable
     std::vector<std::string> wrenchSensorsLinkNames;
 
-    // Wrench source name and type map
-    std::map<std::string, WrenchSourceType> wrenchSourceNameAndTypeMap;
+    // Wrench source name and type
+    std::vector<std::pair<std::string, WrenchSourceType>> wrenchSourceNameAndType;
 
     // Vector of links with ficticious wrench sources
     std::vector<std::string> ficticiousWrenchLinks;
@@ -2233,14 +2233,6 @@ void HumanDynamicsEstimator::run()
         pImpl->measurementsFile << pImpl->berdyData.buffers.measurements.toString().c_str() << std::endl;
     }
 
-    // TODO: Check if this call to updateKinematicsFromFloatingBase is needed
-    // updateEstimateInformationFloatingBase calls updateKinematicsFromFloatingBase in the backend of berdy helper
-    // Set the kinematic information necessary for the dynamics estimation
-    pImpl->berdyData.helper.updateKinematicsFromFloatingBase(pImpl->berdyData.state.jointsPosition,
-                                                             pImpl->berdyData.state.jointsVelocity,
-                                                             pImpl->berdyData.state.floatingBaseFrameIndex,
-                                                             pImpl->berdyData.state.baseAngularVelocity);
-
     // Update estimator information
     pImpl->berdyData.solver->updateEstimateInformationFloatingBase(pImpl->berdyData.state.jointsPosition,
                                                                    pImpl->berdyData.state.jointsVelocity,
@@ -2295,50 +2287,34 @@ void HumanDynamicsEstimator::run()
         pImpl->berdyData.helper.extractLinkNetExternalWrenchesFromDynamicVariables(estimatedDynamicVariables,
                                                                                    pImpl->berdyData.estimates.linkNetExternalWrenchEstimates);
 
-//        pImpl->berdyData.estimates.linkNetExternalWrenchEstimates = pImpl->berdyData.estimates.task1_linkNetExternalWrenchEstimates;
+        for (auto& element : pImpl->wrenchSourceNameAndType) {
 
-        // Using kindyn to compute link
-        iDynTree::KinDynComputations kinDynComputations;
-        kinDynComputations.loadRobotModel(pImpl->humanModel);
-        kinDynComputations.setFloatingBase(pImpl->humanModel.getLinkName(pImpl->berdyData.state.floatingBaseFrameIndex));
-        iDynTree::Vector4 quat;
-        quat.setVal(0, baseOrientation[0]);
-        quat.setVal(1, baseOrientation[1]);
-        quat.setVal(2, baseOrientation[2]);
-        quat.setVal(3, baseOrientation[3]);
+            // Iterate over all the dummy wrench sources
+            if (element.second == WrenchSourceType::Dummy) {
 
-        iDynTree::Rotation rot;
-        rot.fromQuaternion(quat);
+                // Get link index
+                std::string linkName = element.first;
+                int linkIndex = pImpl->humanModel.getLinkIndex(element.first);
 
-        iDynTree::Position pos;
-        pos.setVal(0, basePosition[0]);
-        pos.setVal(1, basePosition[1]);
-        pos.setVal(2, basePosition[2]);
+                // Get link to world transform
+                iDynTree::Transform world_H_link = kinDynComputations.getWorldTransform(linkName);
 
-        iDynTree::Transform baseTransform;
-        baseTransform.setPosition(pos);
-        baseTransform.setRotation(rot);
+                // Set the position to zero
+                world_H_link.setPosition(iDynTree::Position());
 
-        iDynTree::VectorDynSize s, sdot;
-        s.resize(jointsPosition.size());
-        sdot.resize(jointsPosition.size());
-        for (size_t idx = 0; idx < jointsPosition.size(); idx++)
-        {
-            s.setVal(idx, jointsPosition[idx]);
-            sdot.setVal(idx, jointsVelocity[idx]);
+                // Get extracted wrench
+                iDynTree::Wrench linkWrench = pImpl->berdyData.estimates.linkNetExternalWrenchEstimates(linkIndex);
+
+                // Transform extracted wrench estimate with orietation of world frame
+                Eigen::Matrix<double,6,1> transformedWrenchEigen = iDynTree::toEigen(world_H_link.asAdjointTransformWrench()) * iDynTree::toEigen(linkWrench.asVector());
+
+                iDynTree::Wrench transformedLinkWrench;
+                iDynTree::fromEigen(transformedLinkWrench, transformedWrenchEigen);
+
+                pImpl->berdyData.estimates.linkNetExternalWrenchEstimates(linkIndex) = transformedLinkWrench;
+
+            }
         }
-
-        // TODO clean this workaround
-        iDynTree::Vector3 gravity;
-        gravity.zero();
-        gravity(0) = pImpl->gravity(0);
-        gravity(1) = pImpl->gravity(1);
-        gravity(2) = pImpl->gravity(2);
-        kinDynComputations.setRobotState(baseTransform,
-                                         s,
-                                         iDynTree::Twist::Zero(),
-                                         sdot,
-                                         gravity);
 
 
         // Check to ensure all the links net external wrenches are extracted correctly
@@ -2461,15 +2437,15 @@ bool HumanDynamicsEstimator::attach(yarp::dev::PolyDriver* poly)
         // Check the interface
         if (pImpl->iHumanWrench->getNumberOfWrenchSources() == 0
                 || pImpl->iHumanWrench->getNumberOfWrenchSources() != pImpl->iHumanWrench->getWrenchSourceNames().size()
-                || pImpl->iHumanWrench->getNumberOfWrenchSources() != pImpl->iHumanWrench->getWrenchSourceNameAndTypeMap().size()) {
+                || pImpl->iHumanWrench->getNumberOfWrenchSources() != pImpl->iHumanWrench->getWrenchSourceNameAndType().size()) {
             yError() << "The IHumanWrench interface might not be ready";
             return false;
         }
 
-        // Get wrench source name and types map from the attached IHumanWrench interface
-        std::map<std::string, WrenchSourceType> nameAndType = pImpl->iHumanWrench->getWrenchSourceNameAndTypeMap();
+        // Get wrench source name and types from the attached IHumanWrench interface
+        std::vector<std::pair<std::string, WrenchSourceType>> nameAndType = pImpl->iHumanWrench->getWrenchSourceNameAndType();
 
-        // Update wrenchSourceNameAndTypeMap with link names from wrench_sensors_link_name config parameter
+        // Update wrenchSourceNameAndType with link names from wrench_sensors_link_name config parameter
         // NOTE: Assuming wrench_sensors_link_name passes the links corresponding
         // to the sensors associated from HumanWrenchProvider
         if (nameAndType.size() != pImpl->wrenchSensorsLinkNames.size()) {
@@ -2477,9 +2453,9 @@ bool HumanDynamicsEstimator::attach(yarp::dev::PolyDriver* poly)
             return false;
         }
 
-        int index = 0;
+        size_t index = 0;
         for (auto& element : nameAndType) {
-            pImpl->wrenchSourceNameAndTypeMap[pImpl->wrenchSensorsLinkNames.at(index)] = element.second;
+            pImpl->wrenchSourceNameAndType.push_back(std::pair<std::string, WrenchSourceType>(pImpl->wrenchSensorsLinkNames.at(index), element.second));
             index++;
         }
 
@@ -2630,10 +2606,10 @@ int HumanDynamicsEstimator::calibrateChannel(int /*ch*/, double /*value*/)
 // IHumanWrench
 // ============
 
-std::map<std::string, hde::interfaces::IHumanWrench::WrenchSourceType> HumanDynamicsEstimator::getWrenchSourceNameAndTypeMap() const
+std::vector<std::pair<std::string, hde::interfaces::IHumanWrench::WrenchSourceType>> HumanDynamicsEstimator::getWrenchSourceNameAndType() const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->wrenchSourceNameAndTypeMap;
+    return pImpl->wrenchSourceNameAndType;
 }
 
 std::vector<std::string> HumanDynamicsEstimator::getWrenchSourceNames() const

--- a/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.h
+++ b/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.h
@@ -68,6 +68,7 @@ public:
     int calibrateChannel(int ch, double value) override;
 
     // IHumanWrench
+    std::map<std::string, WrenchSourceType> getWrenchSourceNameAndTypeMap() const override;
     std::vector<std::string> getWrenchSourceNames() const override;
     size_t getNumberOfWrenchSources() const override;
     std::vector<double> getWrenches() const override;

--- a/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.h
+++ b/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.h
@@ -68,7 +68,7 @@ public:
     int calibrateChannel(int ch, double value) override;
 
     // IHumanWrench
-    std::map<std::string, WrenchSourceType> getWrenchSourceNameAndTypeMap() const override;
+    std::vector<std::pair<std::string, WrenchSourceType>> getWrenchSourceNameAndType() const override;
     std::vector<std::string> getWrenchSourceNames() const override;
     size_t getNumberOfWrenchSources() const override;
     std::vector<double> getWrenches() const override;

--- a/devices/HumanWrenchProvider/HumanWrenchProvider.cpp
+++ b/devices/HumanWrenchProvider/HumanWrenchProvider.cpp
@@ -78,7 +78,7 @@ public:
 
     AnalogSensorData analogSensorData;
     std::vector<WrenchSourceData> wrenchSources;
-    std::map<std::string, WrenchSourceType> wrenchSourceNameAndTypeMap;
+    std::vector<std::pair<std::string, WrenchSourceType>> wrenchSourceNameAndType;
 
     // Human variables
     iDynTree::Model humanModel;
@@ -486,12 +486,10 @@ bool HumanWrenchProvider::open(yarp::os::Searchable& config)
         pImpl->wrenchSources.emplace_back(std::move(WrenchSourceData));
     }
 
-    // Update wrenchSourceNameAndType map once
+    // Update wrenchSourceNameAndType once
     for (auto& wrenchSource : pImpl->wrenchSources) {
-        pImpl->wrenchSourceNameAndTypeMap[wrenchSource.name] = wrenchSource.type;
+        pImpl->wrenchSourceNameAndType.push_back(std::pair<std::string, WrenchSourceType>(wrenchSource.name, wrenchSource.type));
     }
-
-    yInfo() << LogPrefix << "Size of map" << pImpl->wrenchSourceNameAndTypeMap.size();
 
     return true;
 }
@@ -947,10 +945,10 @@ int HumanWrenchProvider::calibrateChannel(int /*ch*/, double /*value*/)
 // IHumanWrench
 // ============
 
-std::map<std::string, hde::interfaces::IHumanWrench::WrenchSourceType> HumanWrenchProvider::getWrenchSourceNameAndTypeMap() const
+std::vector<std::pair<std::string, hde::interfaces::IHumanWrench::WrenchSourceType>> HumanWrenchProvider::getWrenchSourceNameAndType() const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->wrenchSourceNameAndTypeMap;
+    return pImpl->wrenchSourceNameAndType;
 }
 
 std::vector<std::string> HumanWrenchProvider::getWrenchSourceNames() const

--- a/devices/HumanWrenchProvider/HumanWrenchProvider.h
+++ b/devices/HumanWrenchProvider/HumanWrenchProvider.h
@@ -66,7 +66,7 @@ public:
     int calibrateChannel(int ch, double value) override;
 
     // IHumanWrench
-    std::map<std::string, WrenchSourceType> getWrenchSourceNameAndTypeMap() const override;
+    std::vector<std::pair<std::string, WrenchSourceType>> getWrenchSourceNameAndType() const override;
     std::vector<std::string> getWrenchSourceNames() const override;
     size_t getNumberOfWrenchSources() const override;
     std::vector<double> getWrenches() const override;

--- a/devices/HumanWrenchProvider/HumanWrenchProvider.h
+++ b/devices/HumanWrenchProvider/HumanWrenchProvider.h
@@ -66,6 +66,7 @@ public:
     int calibrateChannel(int ch, double value) override;
 
     // IHumanWrench
+    std::map<std::string, WrenchSourceType> getWrenchSourceNameAndTypeMap() const override;
     std::vector<std::string> getWrenchSourceNames() const override;
     size_t getNumberOfWrenchSources() const override;
     std::vector<double> getWrenches() const override;

--- a/interfaces/IHumanWrench/IHumanWrench.h
+++ b/interfaces/IHumanWrench/IHumanWrench.h
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 
 namespace hde {
     namespace interfaces {
@@ -23,6 +24,14 @@ class hde::interfaces::IHumanWrench
 public:
     virtual ~IHumanWrench() = default;
 
+    enum class WrenchSourceType
+    {
+        Fixed,
+        Robot,
+        Dummy, // TODO
+    };
+
+    virtual std::map<std::string, WrenchSourceType> getWrenchSourceNameAndTypeMap() const = 0;
     virtual std::vector<std::string> getWrenchSourceNames() const = 0;
     virtual size_t getNumberOfWrenchSources() const = 0;
 

--- a/interfaces/IHumanWrench/IHumanWrench.h
+++ b/interfaces/IHumanWrench/IHumanWrench.h
@@ -11,7 +11,7 @@
 
 #include <string>
 #include <vector>
-#include <map>
+#include <utility>
 
 namespace hde {
     namespace interfaces {
@@ -31,7 +31,7 @@ public:
         Dummy, // TODO
     };
 
-    virtual std::map<std::string, WrenchSourceType> getWrenchSourceNameAndTypeMap() const = 0;
+    virtual std::vector<std::pair<std::string, WrenchSourceType>> getWrenchSourceNameAndType() const = 0;
     virtual std::vector<std::string> getWrenchSourceNames() const = 0;
     virtual size_t getNumberOfWrenchSources() const = 0;
 

--- a/interfaces/IHumanWrench/IHumanWrench.h
+++ b/interfaces/IHumanWrench/IHumanWrench.h
@@ -11,7 +11,6 @@
 
 #include <string>
 #include <vector>
-#include <utility>
 
 namespace hde {
     namespace interfaces {


### PR DESCRIPTION
This small PR addresses the issue https://github.com/robotology/human-dynamics-estimation/issues/182. The major changes are:

- Update `WrenchSourceType` to be in `IHumanWrench` interface and access it in `HumanDynamicsEstimator` device https://github.com/robotology/human-dynamics-estimation/commit/76e02af68a1f5813009d8cf7be036c55b77474bf
- Transform the wrench estimates of dummy source (hands) to express them with orientation of the world frame https://github.com/robotology/human-dynamics-estimation/commit/868ddfecd8978f6acf53bdc1fe8a6a246a95a15c
- Add `expressDummyWrenchEstimatesInWorldOrientation` Boolean config parameter https://github.com/robotology/human-dynamics-estimation/pull/183/commits/06e093ee54ff2db75e088625cd290c6f54c9f7bf

@lrapetti @prashanthr05 @diegoferigo @traversaro 
