### PR TITLE
Correct initialization of base transform and velocity variables

### DIFF
--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -785,7 +785,11 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
     pImpl->jointVelocitiesSolution.resize(nrOfDOFs);
     pImpl->jointVelocitiesSolution.zero();
 
-    pImpl->baseTransformSolution.setRotation(iDynTree::Rotation::Identity());
+    // =======================
+    // INITIALIZE BASE BUFFERS
+    // =======================
+    pImpl->baseTransformSolution = iDynTree::Transform::Identity();
+    pImpl->baseVelocitySolution.zero();
 
     // ================================================
     // INITIALIZE CUSTOM CONSTRAINTS FOR INTEGRATION-IK


### PR DESCRIPTION
This patch addresses https://github.com/robotology/human-dynamics-estimation/issues/195

