### PR TITLE
Add IControlLimits interface to HumanControlBoard

### DIFF
--- a/devices/HumanControlBoard/HumanControlBoard.cpp
+++ b/devices/HumanControlBoard/HumanControlBoard.cpp
@@ -385,3 +385,19 @@ bool HumanControlBoard::getTorques(double* t)
     }
     return true;
 }
+
+bool HumanControlBoard::getLimits(int axis, double *min, double *max)
+{
+    *min = 0;
+    *max = 0;
+    yWarning() << LogPrefix << " no limits defined, all the values will be set to zero.";
+    return true;
+}
+
+bool HumanControlBoard::getVelLimits(int axis, double *min, double *max)
+{
+    *min = 0;
+    *max = 0;
+    yWarning() << LogPrefix << " no velocity limits defined, all the values will be set to zero.";
+    return true;
+}

--- a/devices/HumanControlBoard/HumanControlBoard.h
+++ b/devices/HumanControlBoard/HumanControlBoard.h
@@ -17,6 +17,7 @@
 #include <yarp/dev/IVelocityControl.h>
 #include <yarp/dev/Wrapper.h>
 #include <yarp/os/PeriodicThread.h>
+#include <yarp/dev/IControlLimits.h>
 
 #include <memory>
 
@@ -36,6 +37,7 @@ class hde::devices::HumanControlBoard final
     , public yarp::dev::IPositionControl
     , public yarp::dev::IVelocityControl
     , public yarp::dev::ITorqueControl
+    , public yarp::dev::IControlLimits
 {
 private:
     class impl;
@@ -130,6 +132,12 @@ public:
     bool getTorqueRanges(double* min, double* max) override { return false; }
     bool getMotorTorqueParams(int j, yarp::dev::MotorTorqueParameters* params) override { return false; }
     bool setMotorTorqueParams(int j, const yarp::dev::MotorTorqueParameters params) override { return false; }
+
+    // IControlLimits
+    bool setLimits(int axis, double min, double max) override  { return false; }
+    bool getLimits(int axis, double *min, double *max) override;
+    bool setVelLimits(int axis, double min, double max) override  { return false; }
+    bool getVelLimits(int axis, double *min, double *max) override;
 };
 
 #endif // HDE_DEVICES_HUMANCONTROLBOARD


### PR DESCRIPTION
Currently the `IControlLimits` interface is not exposed by the `HumanControlBoard`.

The objective of the `HumanControlBoard` is to expose the same `YARP` interfaces that are usually exposed by the ControlBoard of a robot. One of the main purpose is to access the human data in Simulink using WB-Toolbox (see https://github.com/robotology/human-dynamics-estimation/issues/88). 

Among those interfaces there is the `IControlLimits` interface. Currently this interface is not implemented in the `HumanControlBoard`, indeed using the `GetLimits` block (from WB-toolbox) cause an error. In same cases, it can be useful to be able to run this block even with the `HumanControlBoard` (e.g. switching from robot to human case), and so I decided to implement this interface.

Since we don't have such limits for the human, I am setting both upper and lower limits to zero and returning a `Warning` message. Eventually in the future we might add some limits defined accordingly to antropometric measurements as done in the human urdfs in `https://github.com/robotology/human-gazebo`.