### PR TITLE
Feature: add vector wise publish in human state wrapper to be read by simulink

### DIFF
--- a/wrappers/HumanStateWrapper/HumanStateWrapper.h
+++ b/wrappers/HumanStateWrapper/HumanStateWrapper.h
@@ -30,6 +30,12 @@ class hde::wrappers::HumanStateWrapper final
 private:
     class impl;
     std::unique_ptr<impl> pImpl;
+    bool publishJointPositionVector;
+    bool publishJointVelocityVector;
+    bool publishBasePositionVector;
+    bool publishBaseVelocityVector;
+    bool publishCoMPositionVector;
+    bool publishCoMVelocityVector;
 
 public:
     HumanStateWrapper();


### PR DESCRIPTION
Added the possibility to publish the output of the IK vector wise, in order to read such information from simulink. 

 the following information can be published: 

- joint Position
-  joint Velocity
-  base Position
-  base Velocity
- CoM Position
- CoM Velocity

The information will be published only if the related port name is set as a parameter in the configuration file, i.e. the following new configuration parameter can be instantiated: 
```
    <param name="jointPositionPortName">$JOINTS_POSITION_PORT_NAME</param>
        <param name="jointVelocityPortName">$JOINTS_VELOCITY_PORT_NAME</param>
 	<param name="basePositionPortName">$BASE_POSITION_PORT_NAME</param>
        <param name="baseVelocityPortName">$BASE_VELOCIY_PORT_NAME</param>
	<param name="CoMPositionPortName">$COM_POSITION_PORT_NAME</param>
        <param name="CoMVelocityPortName">$COM_VELOCITYPORT_NAME</param>
```

C.C. @lrapetti @Yeshasvitvs  @S-Dafarra @nunoguedelha @gabrielenava 
