### PR TITLE
Add fixed-base option to HumanStateProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build*
 *kdev4
 *~
 *.txt.user*
+*.vscode*

--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -20,7 +20,7 @@
     <device type="human_state_provider" name="HumanStateProvider">
         <param name="period">0.02</param>
         <param name="urdf">humanSubject01_66dof.urdf</param>
-        <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">Pelvis</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>

--- a/conf/xml/HumanStateProvider.xml
+++ b/conf/xml/HumanStateProvider.xml
@@ -12,7 +12,7 @@
     <device type="human_state_provider" name="HumanStateProvider">
         <param name="period">0.02</param>
         <param name="urdf">humanSubject01_66dof.urdf</param>
-        <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">Pelvis</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>

--- a/conf/xml/HumanStateProvider_second.xml
+++ b/conf/xml/HumanStateProvider_second.xml
@@ -12,7 +12,7 @@
     <device type="human_state_provider" name="HumanStateProvider_2">
         <param name="period">0.05</param>
         <param name="urdf">humanSubject01_66dof.urdf</param>
-        <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">Pelvis</param>
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>
         <param name="allowIKFailures">true</param>

--- a/conf/xml/RobotStateProvider_Atlas.xml
+++ b/conf/xml/RobotStateProvider_Atlas.xml
@@ -12,7 +12,7 @@
     <device type="human_state_provider" name="RobotStateProvider">
         <param name="period">0.02</param>
         <param name="urdf">atlas.urdf</param>
-        <param name="floatingBaseFrame">(pelvis, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">Pelvis</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>

--- a/conf/xml/RobotStateProvider_Baxter.xml
+++ b/conf/xml/RobotStateProvider_Baxter.xml
@@ -12,7 +12,7 @@
     <device type="human_state_provider" name="RobotStateProvider">
         <param name="period">0.02</param>
         <param name="urdf">baxter.urdf</param>
-        <param name="floatingBaseFrame">(base, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">base</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>

--- a/conf/xml/RobotStateProvider_Human.xml
+++ b/conf/xml/RobotStateProvider_Human.xml
@@ -12,7 +12,7 @@
     <device type="human_state_provider" name="HumanStateProvider">
         <param name="period">0.02</param>
         <param name="urdf">humanSubject01_66dof.urdf</param>
-        <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">Pelvis</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>

--- a/conf/xml/RobotStateProvider_Nao.xml
+++ b/conf/xml/RobotStateProvider_Nao.xml
@@ -12,7 +12,7 @@
     <device type="human_state_provider" name="RobotStateProvider">
         <param name="period">0.02</param>
         <param name="urdf">nao.urdf</param>
-        <param name="floatingBaseFrame">(base_link, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">base_link</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>

--- a/conf/xml/RobotStateProvider_Walkman.xml
+++ b/conf/xml/RobotStateProvider_Walkman.xml
@@ -12,7 +12,7 @@
     <device type="human_state_provider" name="RobotStateProvider">
         <param name="period">0.02</param>
         <param name="urdf">walkman.urdf</param>
-        <param name="floatingBaseFrame">(base_link, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">base_link</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>

--- a/conf/xml/RobotStateProvider_iCub.xml
+++ b/conf/xml/RobotStateProvider_iCub.xml
@@ -12,7 +12,7 @@
     <device type="human_state_provider" name="RobotStateProvider">
         <param name="period">0.02</param>
         <param name="urdf">teleoperation_iCub_model_V_2_5.urdf</param>
-        <param name="floatingBaseFrame">(root_link_fake, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">root_link_fake</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>

--- a/conf/xml/RobotStateProvider_iCub_Pole.xml
+++ b/conf/xml/RobotStateProvider_iCub_Pole.xml
@@ -12,7 +12,7 @@
     <device type="human_state_provider" name="RobotStateProvider">
         <param name="period">0.02</param>
         <param name="urdf">teleoperation_iCub_model_V_2_5.urdf</param>
-        <param name="floatingBaseFrame">(root_link_fake, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">root_link_fake</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>

--- a/conf/xml/hands-pHRI.xml
+++ b/conf/xml/hands-pHRI.xml
@@ -20,7 +20,7 @@
     <device type="human_state_provider" name="HumanStateProvider">
         <param name="period">0.02</param>
         <param name="urdf">humanSubject01_66dof.urdf</param>
-        <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">Pelvis</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>

--- a/conf/xml/pHRI.xml
+++ b/conf/xml/pHRI.xml
@@ -21,7 +21,7 @@
     <device type="human_state_provider" name="HumanStateProvider">
         <param name="period">0.02</param>
         <param name="urdf">humanSubject01_66dof.urdf</param>
-        <param name="floatingBaseFrame">(Pelvis, XsensSuit::vLink::Pelvis)</param>
+        <param name="floatingBaseFrame">Pelvis</param>
         <!-- ikSolver options: pairwised, global, integrationbased -->
         <param name="ikSolver">integrationbased</param>
         <param name="useXsensJointsAngles">false</param>

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -1002,6 +1002,16 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         yInfo() << "CUSTOM CONSTRAINTS are not defined in xml file.";
     }
 
+    // set base velocity constraint to zero if the base is fixed
+    if (pImpl->useFixedBase) {
+        pImpl->baseVelocityLowerLimit.resize(6);
+        pImpl->baseVelocityLowerLimit.zero();
+        pImpl->baseVelocityUpperLimit.resize(6);
+        pImpl->baseVelocityUpperLimit.zero();
+
+        yInfo() << "Using fixed base model, base velocity limits are set to zero";
+    }
+
     // check sizes
     if (pImpl->custom_jointsVelocityLimitsNames.size()
         != pImpl->custom_jointsVelocityLimitsValues.size()) {

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -127,9 +127,6 @@ enum rpcCommand
 // Container of data coming from the wearable interface
 struct WearableStorage
 {
-    // Sensor associated with the base
-    SensorPtr<const sensor::IVirtualLinkKinSensor> baseLinkSensor;
-
     // Maps [model joint / link name] ==> [wearable virtual sensor name]
     //
     // E.g. [Pelvis] ==> [XsensSuit::vLink::Pelvis]. Read from the configuration.
@@ -2413,19 +2410,6 @@ bool HumanStateProvider::attach(yarp::dev::PolyDriver* poly)
         pImpl->wearableStorage.linkSensorsMap[wearableLinkName] =
             pImpl->iWear->getVirtualLinkKinSensor(wearableLinkName);
     }
-
-    // Store the sensor associated as base
-    std::string baseLinkSensorName = pImpl->floatingBaseFrame.wearable;
-    if (pImpl->wearableStorage.linkSensorsMap.find(baseLinkSensorName)
-        == pImpl->wearableStorage.linkSensorsMap.end()) {
-        yError() << LogPrefix
-                 << "Failed to find sensor associated with the base passed in the configuration"
-                 << baseLinkSensorName;
-        return false;
-    }
-
-    pImpl->wearableStorage.baseLinkSensor =
-        pImpl->wearableStorage.linkSensorsMap.at(baseLinkSensorName);
 
     // ============
     // CHECK JOINTS


### PR DESCRIPTION
With this PR we add the possibility to run the `HumanStateProvider` with a fixed base link.

In order to set the fixed base it is sufficient to replace the `floatingBaseFrame ` configuration option with `fixedBaseFrame `.

Note that, currently this option would fix both position and orientation of the base. In the future we can think of having the possibility to fix just one of the two.