### PR TITLE
Update RobotPositionController with remotecontrolboardremapper

### DIFF
--- a/devices/RobotPositionController/RobotPositionController.cpp
+++ b/devices/RobotPositionController/RobotPositionController.cpp
@@ -212,7 +212,6 @@ bool RobotPositionController::open(yarp::os::Searchable& config)
         for (unsigned index = 0; index < jointsList->size(); index++) {
             pImpl->jointNameListFromConfigControlBoards.push_back(jointsList->get(index).asString());
             axesList.addString(jointsList->get(index).asString());
-            yInfo() << "For the part " << controlBoard << " joint name " << jointsList->get(index).asString();
         }
 
 
@@ -223,12 +222,7 @@ bool RobotPositionController::open(yarp::os::Searchable& config)
         yarp::os::Bottle & remoteControlBoardsList = remoteControlBoards.addList();
         remoteControlBoardsList.addString( remotePrefix + "/" + controlBoard);
 
-        yInfo() << "remoteControlBoards string " << remotePrefix << "/" << controlBoard;
         pImpl->options.put("remoteControlBoards",remoteControlBoards.get(0));
-
-
-        //pImpl->options.put("remote", remotePrefix + "/" + controlBoard);
-        //pImpl->options.put("remoteControlBoards",axesNames.get(0));
         pImpl->options.put("localPortPrefix", localPrefix);
 
         yarp::os::Property & remoteControlBoardsOpts = pImpl->options.addGroup("REMOTE_CONTROLBOARD_OPTIONS");

--- a/devices/RobotPositionController/RobotPositionController.cpp
+++ b/devices/RobotPositionController/RobotPositionController.cpp
@@ -212,13 +212,28 @@ bool RobotPositionController::open(yarp::os::Searchable& config)
         for (unsigned index = 0; index < jointsList->size(); index++) {
             pImpl->jointNameListFromConfigControlBoards.push_back(jointsList->get(index).asString());
             axesList.addString(jointsList->get(index).asString());
+            yInfo() << "For the part " << controlBoard << " joint name " << jointsList->get(index).asString();
         }
 
 
         pImpl->options.put("device", "remotecontrolboardremapper");
-        pImpl->options.put("remote", remotePrefix + "/" + controlBoard);
-        pImpl->options.put("local", localPrefix + "/" + controlBoard);
         pImpl->options.put("axesNames",axesNames.get(0));
+
+        yarp::os::Bottle remoteControlBoards;
+        yarp::os::Bottle & remoteControlBoardsList = remoteControlBoards.addList();
+        remoteControlBoardsList.addString( remotePrefix + "/" + controlBoard);
+
+        yInfo() << "remoteControlBoards string " << remotePrefix << "/" << controlBoard;
+        pImpl->options.put("remoteControlBoards",remoteControlBoards.get(0));
+
+
+        //pImpl->options.put("remote", remotePrefix + "/" + controlBoard);
+        //pImpl->options.put("remoteControlBoards",axesNames.get(0));
+        pImpl->options.put("localPortPrefix", localPrefix);
+
+        yarp::os::Property & remoteControlBoardsOpts = pImpl->options.addGroup("REMOTE_CONTROLBOARD_OPTIONS");
+        remoteControlBoardsOpts.put("writeStrict","on");
+
 
         pImpl->remoteControlBoards.at(boardCount) = new yarp::dev::PolyDriver;
         pImpl->remoteControlBoards.at(boardCount)->open(pImpl->options);

--- a/devices/RobotPositionController/RobotPositionController.cpp
+++ b/devices/RobotPositionController/RobotPositionController.cpp
@@ -194,9 +194,31 @@ bool RobotPositionController::open(yarp::os::Searchable& config)
     size_t boardCount = 0;
     int remoteControlBoardJoints = 0;
     for (const auto& controlBoard : controlBoards) {
-        pImpl->options.put("device", "remote_controlboard");
+
+
+        // Get joint names of the control board from configuration
+        if (!(config.check(controlBoard) && config.find(controlBoard).isList())) {
+            yError() << LogPrefix << "joint list option not found or not valid for " << controlBoard << " control board";
+            return false;
+        }
+
+        yarp::os::Bottle* jointsList = config.find(controlBoard).asList();
+        yarp::os::Bottle axesNames;
+        yarp::os::Bottle & axesList = axesNames.addList();
+
+        // Set the number of joints from config file
+        pImpl->nJointsVectorFromConfig.at(boardCount) = jointsList->size();
+
+        for (unsigned index = 0; index < jointsList->size(); index++) {
+            pImpl->jointNameListFromConfigControlBoards.push_back(jointsList->get(index).asString());
+            axesList.addString(jointsList->get(index).asString());
+        }
+
+
+        pImpl->options.put("device", "remotecontrolboardremapper");
         pImpl->options.put("remote", remotePrefix + "/" + controlBoard);
         pImpl->options.put("local", localPrefix + "/" + controlBoard);
+        pImpl->options.put("axesNames",axesNames.get(0));
 
         pImpl->remoteControlBoards.at(boardCount) = new yarp::dev::PolyDriver;
         pImpl->remoteControlBoards.at(boardCount)->open(pImpl->options);
@@ -270,20 +292,6 @@ bool RobotPositionController::open(yarp::os::Searchable& config)
             pImpl->minJerkTrajGeneratorVec.at(boardCount)->init(initEncoderJointPositionsVector);
         }
 
-        // Get joint names of the control board from configuration
-        if (!(config.check(controlBoard) && config.find(controlBoard).isList())) {
-            yError() << LogPrefix << "joint list option not found or not valid for " << controlBoard << " control board";
-            return false;
-        }
-
-        yarp::os::Bottle* jointsList = config.find(controlBoard).asList();
-
-        // Set the number of joints from config file
-        pImpl->nJointsVectorFromConfig.at(boardCount) = jointsList->size();
-
-        for (unsigned index = 0; index < jointsList->size(); index++) {
-            pImpl->jointNameListFromConfigControlBoards.push_back(jointsList->get(index).asString());
-        }
 
         pImpl->options.clear();
         boardCount++;


### PR DESCRIPTION
This PR updated [RobotPositionController](https://github.com/robotology/human-dynamics-estimation/tree/devel/devices/RobotPositionController) to use `remotecontrolboardremapper` instead of  `remote_controlboard` client. As discussed with @kouroshD I am opening the PR to [feature/icub3](https://github.com/robotology/human-dynamics-estimation/tree/feature/icub3) on which this patch is rebased for testing retargeting to `iCub3`.

**UPDATE:** @kouroshD let me know if the PR from [feature/icub3](https://github.com/robotology/human-dynamics-estimation/tree/feature/icub3) is going to be delayed. In that case, I can drop the commit from the rebase and open a PR to devel. 