### PR TITLE
Add mouse camera control

### DIFF
--- a/modules/HumanStateVisualizer/src/main.cpp
+++ b/modules/HumanStateVisualizer/src/main.cpp
@@ -168,6 +168,8 @@ int main(int argc, char* argv[])
 
     viz.camera().setPosition(cameraDeltaPosition);
     viz.camera().setTarget(fixedCameraTarget);
+
+    viz.camera().animator()->enableMouseControl(true);
     
     viz.addModel(modelLoader.model(), "human");
 
@@ -235,6 +237,9 @@ int main(int argc, char* argv[])
     std::array<double, 4> baseOrientationInterface;
     std::vector<double> jointPositionsInterface;
     std::vector<std::string> jointNames;
+    iDynTree::Vector4 baseOrientationQuaternion;
+    iDynTree::Position basePosition;
+    iDynTree::Position basePositionOld = fixedCameraTarget;
 
     iDynTree::Transform wHb = iDynTree::Transform::Identity();
     iDynTree::VectorDynSize joints(viz.modelViz("human").model().getNrOfDOFs());
@@ -261,13 +266,11 @@ int main(int argc, char* argv[])
         jointPositionsInterface = iHumanState->getJointPositions();
         jointNames = iHumanState->getJointNames();
 
-        iDynTree::Vector4 baseOrientationQuaternion;
         baseOrientationQuaternion.setVal(0, baseOrientationInterface.at(0));
         baseOrientationQuaternion.setVal(1, baseOrientationInterface.at(1));
         baseOrientationQuaternion.setVal(2, baseOrientationInterface.at(2));
         baseOrientationQuaternion.setVal(3, baseOrientationInterface.at(3));
 
-        iDynTree::Position basePosition;
         basePosition.setVal(0, basePositionInterface.at(0));
         basePosition.setVal(1, basePositionInterface.at(1));
         basePosition.setVal(2, basePositionInterface.at(2));
@@ -290,8 +293,11 @@ int main(int argc, char* argv[])
         // follow the desired link with the camera
         if ( !useFixedCamera )
         {
+            cameraDeltaPosition = viz.camera().getPosition() - basePositionOld;
             viz.camera().setPosition(basePosition + cameraDeltaPosition);
             viz.camera().setTarget(basePosition);
+
+            basePositionOld = basePosition;
         }
         
         


### PR DESCRIPTION
Given that in https://github.com/robotology/human-dynamics-estimation/pull/232 we switch to iDynTree `devel` branch dependency in CI, I have improved the visualizer by taking advantage of the feature introduced in https://github.com/robotology/idyntree/pull/802 and https://github.com/robotology/idyntree/pull/811 enabling camera control with the mouse.

It is indeed now possible to change the orientation of the camera (even when the camera is following the model, done as suggested by @S-Dafarra in https://github.com/robotology/human-dynamics-estimation/pull/230#discussion_r566211346)

https://user-images.githubusercontent.com/35487806/106453571-ceef0480-6489-11eb-9934-c61ee589b230.mov

