### PR TITLE
Fix Visualizer change of base link

### DIFF
--- a/modules/HumanStateVisualizer/src/main.cpp
+++ b/modules/HumanStateVisualizer/src/main.cpp
@@ -202,7 +202,7 @@ int main(int argc, char* argv[])
     if ( iHumanState->getBaseName() != model.getLinkName(model.getDefaultBaseLink()))
     {
         model.setDefaultBaseLink(model.getLinkIndex(iHumanState->getBaseName()));
-        yInfo() << LogPrefix << "Defaul base link of the visualized model is changed to " << iHumanState->getBaseName();
+        yInfo() << LogPrefix << "Default base link of the visualized model is changed to " << iHumanState->getBaseName();
     }
     yInfo() << LogPrefix << "Human State Interface providing data from [ " << iHumanState->getJointNames().size() << " ] joints";
     

--- a/modules/HumanStateVisualizer/src/main.cpp
+++ b/modules/HumanStateVisualizer/src/main.cpp
@@ -160,18 +160,7 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    // initialize visualization
-    iDynTree::Visualizer viz;
-    iDynTree::VisualizerOptions options;
-
-    viz.init(options);
-
-    viz.camera().setPosition(cameraDeltaPosition);
-    viz.camera().setTarget(fixedCameraTarget);
-
-    viz.camera().animator()->enableMouseControl(true);
-    
-    viz.addModel(modelLoader.model(), "human");
+    iDynTree::Model model = modelLoader.model();
 
     // initialise yarp network
     yarp::os::Network yarp;
@@ -210,16 +199,16 @@ int main(int argc, char* argv[])
      
     // compare the iHumanState base and joint names with the visualization model
     yInfo() << LogPrefix << "Human State Interface providing data for the base link [ " << iHumanState->getBaseName() << " ]";
-    if ( iHumanState->getBaseName() != viz.modelViz("human").model().getLinkName(viz.modelViz("human").model().getDefaultBaseLink()))
+    if ( iHumanState->getBaseName() != model.getLinkName(model.getDefaultBaseLink()))
     {
-        viz.modelViz("human").model().setDefaultBaseLink(viz.modelViz("human").model().getLinkIndex(iHumanState->getBaseName()));
+        model.setDefaultBaseLink(model.getLinkIndex(iHumanState->getBaseName()));
         yInfo() << LogPrefix << "Defaul base link of the visualized model is changed to " << iHumanState->getBaseName();
     }
     yInfo() << LogPrefix << "Human State Interface providing data from [ " << iHumanState->getJointNames().size() << " ] joints";
     
     for (auto jointName : iHumanState->getJointNames())
     {
-        if (viz.modelViz("human").model().getJointIndex(jointName) == iDynTree::JOINT_INVALID_INDEX)
+        if (model.getJointIndex(jointName) == iDynTree::JOINT_INVALID_INDEX)
         {
             if (!ignoreMissingLinks)
             {
@@ -242,8 +231,21 @@ int main(int argc, char* argv[])
     iDynTree::Position basePositionOld = fixedCameraTarget;
 
     iDynTree::Transform wHb = iDynTree::Transform::Identity();
-    iDynTree::VectorDynSize joints(viz.modelViz("human").model().getNrOfDOFs());
+    iDynTree::VectorDynSize joints(model.getNrOfDOFs());
     joints.zero();
+
+    // initialize visualization
+    iDynTree::Visualizer viz;
+    iDynTree::VisualizerOptions options;
+
+    viz.init(options);
+
+    viz.camera().setPosition(cameraDeltaPosition);
+    viz.camera().setTarget(fixedCameraTarget);
+
+    viz.camera().animator()->enableMouseControl(true);
+    
+    viz.addModel(model, "human");
 
     // start Visualization
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();


### PR DESCRIPTION
Currenty, when the model require to change the base link, the change of base is not correctly done.

You can observe in the following video what happen with the iCub2.5 model with `root_link_fake` exposed as base by the `iHumanState`

https://user-images.githubusercontent.com/35487806/106469259-5c891f00-649f-11eb-832a-a0756f5704fe.mov

The cause of the problem is reported by the following observation by @S-Dafarra 
> When setting the `model` to the visualizer with https://github.com/robotology/idyntree/blob/devel/src/visualization/include/iDynTree/Visualizer.h#L750, it uses [`Model::getDefaultBaseLink()`](https://github.com/robotology/idyntree/blob/devel/src/model/include/iDynTree/Model/Model.h#L457) to determine the base link. You can change it with [`Model::setDefaultBaseLink()`](https://github.com/robotology/idyntree/blob/devel/src/model/include/iDynTree/Model/Model.h#L446) before adding the model to the visualizer.
> 
> Edit: Indeed, what you are doing in https://github.com/robotology/human-dynamics-estimation/blob/master/modules/HumanStateVisualizer/src/main.cpp#L211-L215 is correct
> 
> Edit Edit: If you change the base link in the model you already loaded, this change has an effect only if it is done before calling the `init()` method of the visualizer.

Following this suggestion, this PR fixes the implementation.
As you can see, with the following source data, the model now behave as expected

https://user-images.githubusercontent.com/35487806/106469491-a83bc880-649f-11eb-9b64-9a4664742c7d.mov


