### PR TITLE
Update iDynTree tag in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
     vcpkg_robotology_TAG: v0.6.0
     YCM_TAG: v0.12.0
     YARP_TAG: v3.4.1
-    iDynTree_TAG: devel 
+    iDynTree_TAG: v3.0.0 
     wearables_TAG: v1.1.0 
     icub_main_TAG: v1.17.0    
     osqp_TAG: v0.6.0


### PR DESCRIPTION
Following the release of `iDynTree 3.0.0` (https://github.com/robotology/community/discussions/481), I am updating the tag in the CI.

In this way we depend again on a stable branch of the repo (see https://github.com/robotology/human-dynamics-estimation/issues/231#issuecomment-772693848)