### PR TITLE
Add visualizer to yarpmanager applications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(HumanDynamicsEstimation
         LANGUAGES CXX
-        VERSION 2.1.0)
+        VERSION 2.2.0)
 
 # =====================
 # PROJECT CONFIGURATION

--- a/conf/app/HumanStateVisualizer.ini
+++ b/conf/app/HumanStateVisualizer.ini
@@ -2,11 +2,11 @@ name                    HumanStateVisualizer
 
 # Model Configuration options
 modelURDFName      "humanSubject01_66dof.urdf"
-ignoreMissingLinks  1
+ignoreMissingLinks  true
 
 # Camera options
 cameraDeltaPosition  (2.0, 0.0, 0.5)
-useFixedCamera       0               # if set to false, the camera follows the model base link
+useFixedCamera       false           # if set to false, the camera follows the model base link
 fixedCameraTarget    (0.0, 0.0, 0.0) # this option is unused when useFixedCamera is false
 maxVisualizationFPS  65
 

--- a/conf/app/HumanStateVisualizer_iCub2_5.ini
+++ b/conf/app/HumanStateVisualizer_iCub2_5.ini
@@ -2,11 +2,11 @@ name                    HumanStateVisualizer
 
 # Model Configuration options
 modelURDFName      "teleoperation_iCub_model_V_2_5.urdf"
-ignoreMissingLinks  1
+ignoreMissingLinks  true
 
 # Camera options
 cameraDeltaPosition  (0.0, 2.0, 0.5)
-useFixedCamera       0               # if set to false, the camera follows the model base link
+useFixedCamera       false           # if set to false, the camera follows the model base link
 fixedCameraTarget    (0.0, 0.0, 0.0) # this option is unused when useFixedCamera is false
 maxVisualizationFPS  65
 

--- a/conf/app/HumanStateVisualizer_iCub3.ini
+++ b/conf/app/HumanStateVisualizer_iCub3.ini
@@ -1,0 +1,14 @@
+name                    HumanStateVisualizer
+
+# Model Configuration options
+modelURDFName      "teleoperation_iCub_model_V_3.urdf"
+ignoreMissingLinks  true
+
+# Camera options
+cameraDeltaPosition  (0.0, 2.0, 0.5)
+useFixedCamera       false           # if set to false, the camera follows the model base link
+fixedCameraTarget    (0.0, 0.0, 0.0) # this option is unused when useFixedCamera is false
+maxVisualizationFPS  65
+
+# Remapper Configuration
+humanStateDataPortName "/iCub/RobotStateWrapper/state:o"

--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -160,7 +160,7 @@
     </device>
 
     <!-- Uncomment to stream the output of HumanStateProvider on a YARP port -->
-    <!-- <device type="human_state_wrapper" name="HumanStateWrapper">
+    <device type="human_state_wrapper" name="HumanStateWrapper">
         <param name="period">0.02</param>
         <param name="outputPort">/HDE/HumanStateWrapper/state:o</param>
         <action phase="startup" level="5" type="attach">
@@ -169,7 +169,7 @@
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device> -->
+    </device>
 
     <!-- An HumanStateRemapper device can be used to attach directly to a HumanStateWrapper port without running HumanStateProvider device -->
     <!-- <device type="human_state_remapper" name="HumanStateRemapper">

--- a/conf/xml/applications/HumanDynamicsEstimation-HumanDynamics.xml
+++ b/conf/xml/applications/HumanDynamicsEstimation-HumanDynamics.xml
@@ -24,6 +24,18 @@
     <node>localhost</node>
   </module>
 
+  <!--iDynTree human visualizer-->
+  <module>
+    <name>HumanStateVisualizer</name>
+    <parameters>--from HumanStateVisualizer.ini</parameters>
+    <dependencies>
+          <port timeout="5.0">/HDE/HumanStateWrapper/state:o</port>
+    </dependencies>
+    <environment>YARP_FORWARD_LOG_ENABLE=1</environment>
+    <description>Run the iDynTree Human Visualizer</description>
+    <node>localhost</node>
+  </module>
+
   <!--yarprobotstatepublisher for human-->
   <module>
     <name>yarprobotstatepublisher</name>

--- a/conf/xml/applications/HumanDynamicsEstimation-HumanKinematics.xml
+++ b/conf/xml/applications/HumanDynamicsEstimation-HumanKinematics.xml
@@ -24,6 +24,18 @@
     <node>localhost</node>
   </module>
 
+  <!--iDynTree human visualizer-->
+  <module>
+    <name>HumanStateVisualizer</name>
+    <parameters>--from HumanStateVisualizer.ini</parameters>
+    <dependencies>
+          <port timeout="5.0">/HDE/HumanStateWrapper/state:o</port>
+    </dependencies>
+    <environment>YARP_FORWARD_LOG_ENABLE=1</environment>
+    <description>Run the iDynTree Human Visualizer</description>
+    <node>localhost</node>
+  </module>
+
   <!--yarprobotstatepublisher for human-->
   <module>
     <name>yarprobotstatepublisher</name>

--- a/conf/xml/applications/XsensRetargetingVisualizationiCub2_5.xml
+++ b/conf/xml/applications/XsensRetargetingVisualizationiCub2_5.xml
@@ -4,7 +4,7 @@
 
 <application>
 
-  <name>XsensRetargetingVisualization</name>
+  <name>XsensRetargetingVisualization iCub2.5</name>
   <description>visualization of IK for retargeting</description>
   <version>1.0</version>
   <authors>
@@ -22,6 +22,18 @@
   <module>
     <name>yarprobotinterface</name>
     <parameters>--config RobotStateProvider_iCub2_5.xml</parameters>
+    <node>localhost</node>
+  </module>
+
+  <!--iDynTree human visualizer-->
+  <module>
+    <name>HumanStateVisualizer</name>
+    <parameters>--from HumanStateVisualizer_iCub2_5.ini</parameters>
+    <dependencies>
+          <port timeout="5.0">/iCub/RobotStateWrapper/state:o</port>
+    </dependencies>
+    <environment>YARP_FORWARD_LOG_ENABLE=1</environment>
+    <description>Run the iDynTree Visualizer</description>
     <node>localhost</node>
   </module>
 

--- a/conf/xml/applications/XsensRetargetingVisualizationiCub3.xml
+++ b/conf/xml/applications/XsensRetargetingVisualizationiCub3.xml
@@ -4,7 +4,7 @@
 
 <application>
 
-  <name>XsensRetargetingVisualization</name>
+  <name>XsensRetargetingVisualization iCub3</name>
   <description>visualization of IK for retargeting</description>
   <version>1.0</version>
   <authors>
@@ -25,6 +25,17 @@
     <node>localhost</node>
   </module>
 
+  <!--iDynTree human visualizer-->
+  <module>
+    <name>HumanStateVisualizer</name>
+    <parameters>--from HumanStateVisualizer_iCub3.ini</parameters>
+    <dependencies>
+          <port timeout="5.0">/iCub/RobotStateWrapper/state:o</port>
+    </dependencies>
+    <environment>YARP_FORWARD_LOG_ENABLE=1</environment>
+    <description>Run the iDynTree Visualizer</description>
+    <node>localhost</node>
+  </module>
 
   <module>
       <name>yarprobotstatepublisher</name>

--- a/modules/HumanStateVisualizer/src/main.cpp
+++ b/modules/HumanStateVisualizer/src/main.cpp
@@ -88,12 +88,14 @@ int main(int argc, char* argv[])
     if( !(rf.check("modelURDFName") && rf.find("modelURDFName").isString()) ) 
     {
         yError() << LogPrefix << "'modelURDFName' option not found or not valid.";
+        return EXIT_FAILURE;
     }
     std::string urdfFile = rf.find("modelURDFName").asString();
 
     if( !(rf.check("ignoreMissingLinks") && rf.find("ignoreMissingLinks").isBool()) ) 
     {
         yError() << LogPrefix << "'ignoreMissingLinks' option not found or not valid.";
+        return EXIT_FAILURE;
     }
     bool ignoreMissingLinks = rf.find("ignoreMissingLinks").asBool();
 
@@ -101,12 +103,14 @@ int main(int argc, char* argv[])
     if( !(rf.check("cameraDeltaPosition") && rf.find("cameraDeltaPosition").isList() && rf.find("cameraDeltaPosition").asList()->size() == 3) ) 
     {
         yError() << LogPrefix << "'cameraDeltaPosition' option not found or not valid.";
+        return EXIT_FAILURE;
     }
     for (size_t idx = 0; idx < 3; idx++)
     {
         if ( !(rf.find("cameraDeltaPosition").asList()->get(idx).isDouble()) )
         {
             yError() << LogPrefix << "'cameraDeltaPosition' entry [ " << idx << " ] is not valid.";
+            return EXIT_FAILURE;
         }
         cameraDeltaPosition.setVal(idx, rf.find("cameraDeltaPosition").asList()->get(idx).asDouble());
     }
@@ -114,6 +118,7 @@ int main(int argc, char* argv[])
     if( !(rf.check("useFixedCamera") && rf.find("useFixedCamera").isBool()) ) 
     {
         yError() << LogPrefix << "'useFixedCamera' option not found or not valid.";
+        return EXIT_FAILURE;
     }
     bool useFixedCamera = rf.find("useFixedCamera").asBool();
 
@@ -123,12 +128,14 @@ int main(int argc, char* argv[])
         if( !(rf.check("fixedCameraTarget") && rf.find("fixedCameraTarget").isList() && rf.find("fixedCameraTarget").asList()->size() == 3) ) 
         {
             yError() << LogPrefix << "'fixedCameraTarget' option not found or not valid.";
+            return EXIT_FAILURE;
         }
         for (size_t idx = 0; idx < 3; idx++)
         {
             if ( !(rf.find("fixedCameraTarget").asList()->get(idx).isDouble()) )
             {
                 yError() << LogPrefix << "'fixedCameraTarget' entry [ " << idx << " ] is not valid.";
+                return EXIT_FAILURE;
             }
             fixedCameraTarget.setVal(idx, rf.find("fixedCameraTarget").asList()->get(idx).asDouble());
         }
@@ -137,12 +144,14 @@ int main(int argc, char* argv[])
     if( !(rf.check("maxVisualizationFPS") && rf.find("maxVisualizationFPS").isInt() && rf.find("maxVisualizationFPS").asInt() > 0) ) 
     {
         yError() << LogPrefix << "'maxVisualizationFPS' option not found or not valid.";
+        return EXIT_FAILURE;
     }
     unsigned int maxVisualizationFPS = rf.find("maxVisualizationFPS").asInt();
 
     if( !(rf.check("humanStateDataPortName") && rf.find("humanStateDataPortName").isString()) ) 
     {
         yError() << LogPrefix << "'humanStateDataPortName' option not found or not valid.";
+        return EXIT_FAILURE;
     }
     std::string humanStateDataPortName = rf.find("humanStateDataPortName").asString();
 


### PR DESCRIPTION
This PR adds the HumanStateVisualizer to the following yarpmanager applications:
- `HumanDynamicsEstimation-HumanKinematics.xml`
- `HumanDynamicsEstimation-HumanDynamics.xml`
- `XsensRetargetingVisualizationiCub2_5.xml`
- `XsensRetargetingVisualizationiCub3.xml`

Moreover, some minor fixies are added to this PR:
- code version is updated in the CMakeLists to v2.2.0 (leftover from https://github.com/robotology/human-dynamics-estimation/issues/231)
- configuration option parsing was not returning `EXIT_FAILURE` in some error cases (and indeed some wrong options were not detected)