### PR TITLE
Add force arrows to the HumanStateVisualizer

### DIFF
--- a/conf/app/HumanStateVisualizer.ini
+++ b/conf/app/HumanStateVisualizer.ini
@@ -3,6 +3,7 @@ name                    HumanStateVisualizer
 # Model Configuration options
 modelURDFName      "humanSubject01_66dof.urdf"
 ignoreMissingLinks  true
+visualizeWrenches   true
 
 # Camera options
 cameraDeltaPosition  (2.0, 0.0, 0.5)
@@ -10,5 +11,10 @@ useFixedCamera       false           # if set to false, the camera follows the m
 fixedCameraTarget    (0.0, 0.0, 0.0) # this option is unused when useFixedCamera is false
 maxVisualizationFPS  65
 
+# Wrench Data Configuration
+forceScalingFactor   0.001
+wrenchSourceLinks    (LeftFoot RightFoot) # link order should reflect WrenchWrapper port data
+
 # Remapper Configuration
 humanStateDataPortName "/HDE/HumanStateWrapper/state:o"
+humanWrenchWrapperPortName "/HDE/HumanWrenchWrapper/wrench:o"

--- a/conf/app/HumanStateVisualizerWithDynamics.ini
+++ b/conf/app/HumanStateVisualizerWithDynamics.ini
@@ -3,7 +3,7 @@ name                    HumanStateVisualizer
 # Model Configuration options
 modelURDFName      "humanSubject01_66dof.urdf"
 ignoreMissingLinks  true
-visualizeWrenches   false
+visualizeWrenches   true
 
 # Camera options
 cameraDeltaPosition  (2.0, 0.0, 0.5)
@@ -11,5 +11,10 @@ useFixedCamera       false           # if set to false, the camera follows the m
 fixedCameraTarget    (0.0, 0.0, 0.0) # this option is unused when useFixedCamera is false
 maxVisualizationFPS  65
 
+# Wrench Data Configuration
+forceScalingFactor   0.001
+wrenchSourceLinks    (LeftFoot RightFoot) # link order should reflect WrenchWrapper port data
+
 # Remapper Configuration
 humanStateDataPortName "/HDE/HumanStateWrapper/state:o"
+humanWrenchWrapperPortName "/HDE/HumanWrenchWrapper/wrench:o"

--- a/conf/app/HumanStateVisualizer_iCub2_5.ini
+++ b/conf/app/HumanStateVisualizer_iCub2_5.ini
@@ -3,6 +3,7 @@ name                    HumanStateVisualizer
 # Model Configuration options
 modelURDFName      "teleoperation_iCub_model_V_2_5.urdf"
 ignoreMissingLinks  true
+visualizeWrenches   false
 
 # Camera options
 cameraDeltaPosition  (0.0, 2.0, 0.5)

--- a/conf/app/HumanStateVisualizer_iCub3.ini
+++ b/conf/app/HumanStateVisualizer_iCub3.ini
@@ -3,6 +3,7 @@ name                    HumanStateVisualizer
 # Model Configuration options
 modelURDFName      "teleoperation_iCub_model_V_3.urdf"
 ignoreMissingLinks  true
+visualizeWrenches   false
 
 # Camera options
 cameraDeltaPosition  (0.0, 2.0, 0.5)

--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -229,7 +229,7 @@
         <action phase="shutdown" level="5" type="detach" />
     </device>
 
-    <!--device type="analogServer" name="HumanWrenchWrapper">
+    <device type="analogServer" name="HumanWrenchWrapper">
         <param name="name">/HDE/HumanWrenchWrapper/wrench:o</param>
         <param name="period">10</param>
         <action phase="startup" level="5" type="attach">
@@ -238,7 +238,7 @@
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach" />
-    </device-->
+    </device>
 
     <!--Wrapper to publish WrenchStamped message to Rviz-->
     <device type="analogServer" name="HumanWrenchPublisher">

--- a/conf/xml/applications/HumanDynamicsEstimation-HumanDynamics.xml
+++ b/conf/xml/applications/HumanDynamicsEstimation-HumanDynamics.xml
@@ -1,20 +1,12 @@
 <application>
   <name>HumanDynamicsEstimation-HumanDynamics</name>
   <description>An application for running Human Dynamics Estimation (HDE) for only human</description>
-
-  <module>
-    <name>yarprobotinterface</name>
-    <parameters>--config TransformServer.xml</parameters>
-    <node>localhost</node>
-  </module>
   
   <!--yarprobotinterface with HDE config file for only human-->
   <module>
     <name>yarprobotinterface</name>
     <parameters>--config Human.xml</parameters>
     <dependencies>
-          <port timeout="5.0">/transformServer/rpc</port>
-          <port timeout="5.0">/transformServer/transforms:o</port>
           <port timeout="5.0">/XSensSuit/WearableData/data:o</port>
           <port timeout="5.0">/FTShoeLeft/WearableData/data:o</port>
           <port timeout="5.0">/FTShoeRight/WearableData/data:o</port>
@@ -27,7 +19,7 @@
   <!--iDynTree human visualizer-->
   <module>
     <name>HumanStateVisualizer</name>
-    <parameters>--from HumanStateVisualizer.ini</parameters>
+    <parameters>--from HumanStateVisualizerWithDynamics.ini</parameters>
     <dependencies>
           <port timeout="5.0">/HDE/HumanStateWrapper/state:o</port>
     </dependencies>


### PR DESCRIPTION
This PR close https://github.com/robotology/human-dynamics-estimation/issues/240 by adding the possibility to visualize the force associated to a given link by reading its value from the `HumanWrenchProvider` trough an `analogServer`.

The PR is ready, as shown in https://github.com/robotology/human-dynamics-estimation/issues/240#issuecomment-789165160, but waiting for a fix in `iDynTree` to be merged (https://github.com/robotology/idyntree/pull/838)