### PR TITLE
HumanDynamicsPublisher: Fix missing link to iDynTree::idyntree-modelio-urdf

### DIFF
--- a/publishers/HumanDynamicsPublisher/CMakeLists.txt
+++ b/publishers/HumanDynamicsPublisher/CMakeLists.txt
@@ -24,7 +24,8 @@ target_link_libraries(HumanDynamicsPublisher PUBLIC
     YARP::YARP_OS
     YARP::YARP_dev
     YARP::YARP_init
-    YARP::YARP_rosmsg)
+    YARP::YARP_rosmsg
+    iDynTree::idyntree-modelio-urdf)
 
 yarp_install(
     TARGETS HumanDynamicsPublisher


### PR DESCRIPTION
The `HumanDynamicsPublisher` device is using the `iDynTree/ModelIO/ModelLoader.h` header, but the correct iDynTree target is not linked in CMake. This works fine if YARP and iDynTree are installed in the same prefix (as it happens in Continuous Integration), but if for any reason YARP and iDynTree are installed in different directories, the compilation will fail as `iDynTree/ModelIO/ModelLoader.h` is not found in the include path.