### PR TITLE
Add Human State Provider new features

### DIFF
--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -1632,6 +1632,10 @@ bool HumanStateProvider::impl::getLinkTransformFromInputData(
     return true;
 }
 
+// In case it occurs that:
+// - Fixed-base is used for human-state-provider
+// - a sensor is associated with the fixed base frame
+// then we use the relative transform between the sensors and the base frame sensors
 bool HumanStateProvider::impl::computeRelativeTransformForInputData(
     std::unordered_map<std::string, iDynTree::Transform>& transforms)
 {


### PR DESCRIPTION
This PR introduces some new features for the `HumanStateProvider`:
- Add the possibility to run fixed-based inverse kineamtics, using a sensor as fixed base, and computing the other sensors relative pose (https://github.com/robotology/human-dynamics-estimation/commit/1381f42de3783913aa859d65b877ad1bd699fe63)
- Add optional `jointList` parameter for `HumanStateProvider` device: Add the possibility to use a reduced model by passing list of links from the configuration (https://github.com/robotology/human-dynamics-estimation/commit/5d6dde63c3e2cd998d7f78da53c93866db75c740).
- Add the possibility to pass a fixed rotation for a sensor measurement trough configuration files (https://github.com/robotology/human-dynamics-estimation/commit/a4b383cc320df60980698ac2b7269bacef42ba0b)