### PR TITLE
Fix joint limits read

### DIFF
--- a/conf/urdfs/teleoperation_iCub_model_V_3.urdf
+++ b/conf/urdfs/teleoperation_iCub_model_V_3.urdf
@@ -864,12 +864,13 @@
       </geometry>
     </collision>
   </link>
-  <joint name="r_wrist_yaw" type="continuous">
+  <joint name="r_wrist_yaw" type="revolute">
     <origin xyz="-0.016300122874272734 0.0069993900510918194 0" rpy="0 0 0"/>
     <axis xyz="-2.4949582809984105e-07 1.0000002733514362 -2.7942487004772865e-08"/>
     <parent link="r_wrist_1"/>
     <child link="r_hand"/>
-    <dynamics damping="0.1"/>
+    <limit effort="50000" lower="-0.2617993877991494" upper="0.6108652381980153" velocity="120.0"/>
+    <dynamics damping="0.06" friction="0.0"/>
   </joint>
   <link name="neck_1">
     <inertial>

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -2050,9 +2050,13 @@ bool HumanStateProvider::impl::initializeIntegrationBasedInverseKinematicsSolver
     jointLowerLimits.resize(humanModel.getNrOfDOFs());
     iDynTree::VectorDynSize jointUpperLimits;
     jointUpperLimits.resize(humanModel.getNrOfDOFs());
-    for (int jointIndex = 0; jointIndex < humanModel.getNrOfDOFs(); jointIndex++) {
-        jointLowerLimits.setVal(jointIndex, humanModel.getJoint(jointIndex)->getMinPosLimit(0));
-        jointUpperLimits.setVal(jointIndex, humanModel.getJoint(jointIndex)->getMaxPosLimit(0));
+    size_t DOFIndex = 0;
+    for (size_t jointIndex = 0; jointIndex < humanModel.getNrOfJoints(); ++jointIndex) {
+        if (humanModel.getJoint(jointIndex)->getNrOfDOFs() == 1) {
+            jointLowerLimits.setVal(DOFIndex, humanModel.getJoint(jointIndex)->getMinPosLimit(0));
+            jointUpperLimits.setVal(DOFIndex, humanModel.getJoint(jointIndex)->getMaxPosLimit(0));
+            DOFIndex++;
+        }
     }
     stateIntegrator.setJointLimits(jointLowerLimits, jointUpperLimits);
 


### PR DESCRIPTION
Currently, there is a bug in the joint limits that are passed to the `stateIntegrator`. The error is due to the fact that we are iterating on DOFs but then the output is used for reading the joint.
The issue should be fixed by this PR.

In addition, I am fixing the iCub3 teleoperation model on the right wrist (see https://github.com/robotology/icub-models/issues/93)