### PR TITLE
Fix calibration matrices order in HumanStateProvider

### DIFF
--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -1140,6 +1140,13 @@ void HumanStateProvider::run()
         return;
     }
 
+    // Apply the secondary calibration to input data
+    if (!pImpl->applyFixedRightRotationForInputTransformData(pImpl->linkTransformMatricesRaw)) {
+        yError() << LogPrefix << "Failed to apply fixed calibration to input data";
+        askToStop();
+        return;
+    }
+
     // Get the link transformations from input data
     if (pImpl->useFixedBase)
     {
@@ -1150,12 +1157,7 @@ void HumanStateProvider::run()
         }
     }
 
-    // Apply the secondary calibration to input data
-    if (!pImpl->applyFixedRightRotationForInputTransformData(pImpl->linkTransformMatricesRaw)) {
-        yError() << LogPrefix << "Failed to apply fixed calibration to input data";
-        askToStop();
-        return;
-    }
+    
 
 
     // Apply the secondary calibration to input data


### PR DESCRIPTION
Changing the order of the call to the fixed rotation and relative rotation computation. This allows using the fixed base together with the fixed rotation fixing https://github.com/robotology/human-dynamics-estimation/issues/269.

I have already tested the usage of a fixed rotation for the base frame with few sensors. I will test it again in a more complex scenario before merging