### PR TITLE
Human State Provider: fix the bug related to the zero output qp solver

### DIFF
--- a/HumanDynamicsEstimationLibrary/algorithms/include/hde/algorithms/DynamicalInverseKinematics.hpp
+++ b/HumanDynamicsEstimationLibrary/algorithms/include/hde/algorithms/DynamicalInverseKinematics.hpp
@@ -39,9 +39,8 @@ public:
     bool setLinearJointConfigurationLimits(const std::vector<iDynTree::JointIndex>& jointsIndexList,
                                            const iDynTree::VectorDynSize& upperBoundary,
                                            const iDynTree::VectorDynSize& lowerBoundary,
-                                           const iDynTree::MatrixDynSize& customConstraintMatrix,
-                                           const double k_u,
-                                           const double k_l); 
+                                           const iDynTree::MatrixDynSize& customConstraintMatrix);
+    bool setConstraintParametersJointValues(const double& k_u, const double& k_l);
     bool setAllJointsVelocityLimit(const double limit);
     bool setBaseVelocityLimit(const iDynTree::VectorDynSize& lowerLimit,
                               const iDynTree::VectorDynSize& upperLimit);

--- a/HumanDynamicsEstimationLibrary/algorithms/include/hde/algorithms/InverseVelocityKinematics.hpp
+++ b/HumanDynamicsEstimationLibrary/algorithms/include/hde/algorithms/InverseVelocityKinematics.hpp
@@ -96,9 +96,9 @@ public:
     bool setCustomConstraintsJointsValues(const std::vector<iDynTree::JointIndex>& jointsIndexList,
                                           const iDynTree::VectorDynSize& upperBoundary,
                                           const iDynTree::VectorDynSize& lowerBoundary,
-                                          const iDynTree::MatrixDynSize& customConstraintMatrix,
-                                          const double k_u,
-                                          const double k_l);
+                                          const iDynTree::MatrixDynSize& customConstraintMatrix);
+
+    bool setConstraintParametersJointValues(const double& k_u, const double& k_l);
 
     bool setGeneralJointVelocityConstraints(const double jointVelocityLimit);
 

--- a/HumanDynamicsEstimationLibrary/algorithms/src/DynamicalInverseKinematics.cpp
+++ b/HumanDynamicsEstimationLibrary/algorithms/src/DynamicalInverseKinematics.cpp
@@ -666,12 +666,16 @@ bool DynamicalInverseKinematics::impl::initialize()
     }
     if (!m_inverseVelocityKinematics.setGeneralJointVelocityConstraints(100)) // dummy value, that will be replaced by the custom joint velocity limits
         return false; 
-    if (!m_inverseVelocityKinematics.setGeneralJointsUpperLowerConstraints(m_limits.jointPositionUpperLimit,
-                                                                           m_limits.jointPositionLowerLimit))
+
+    if (!m_inverseVelocityKinematics.setConstraintParametersJointValues(m_linearLimits.k_u,
+                                                                        m_linearLimits.k_l))
         return false;
-    
-    if (m_limits.jointVelocityUpperLimit.size() > 0)
-    {
+
+    if (!m_inverseVelocityKinematics.setGeneralJointsUpperLowerConstraints(
+            m_limits.jointPositionUpperLimit, m_limits.jointPositionLowerLimit))
+        return false;
+
+    if (m_limits.jointVelocityUpperLimit.size() > 0) {
         std::vector<iDynTree::JointIndex> jointsList;
         jointsList.clear();
         for (size_t i = 0; i < m_dofs; i++)
@@ -679,14 +683,12 @@ bool DynamicalInverseKinematics::impl::initialize()
         if (!m_inverseVelocityKinematics.setCustomJointsVelocityLimit(jointsList, m_limits.jointVelocityUpperLimit))
             return false;
     }
-    if (m_linearLimits.constraintVariablesIndex.size() > 0)
-    {
-        if (!m_inverseVelocityKinematics.setCustomConstraintsJointsValues(m_linearLimits.constraintVariablesIndex,
-                                                                          m_linearLimits.constraintUpperBound,
-                                                                          m_linearLimits.constraintLowerBound,
-                                                                          m_linearLimits.constraintMatrix,
-                                                                          m_linearLimits.k_u,
-                                                                          m_linearLimits.k_l))
+    if (m_linearLimits.constraintVariablesIndex.size() > 0) {
+        if (!m_inverseVelocityKinematics.setCustomConstraintsJointsValues(
+                m_linearLimits.constraintVariablesIndex,
+                m_linearLimits.constraintUpperBound,
+                m_linearLimits.constraintLowerBound,
+                m_linearLimits.constraintMatrix))
             return false;
     }
 
@@ -875,12 +877,12 @@ void DynamicalInverseKinematics::setInverseVelocityKinematicsRegularization(cons
     pImpl->m_inverseVelocityKinematics.setRegularization(regularizationWeight);
 }
 
-bool DynamicalInverseKinematics::setLinearJointConfigurationLimits(const std::vector<iDynTree::JointIndex>& jointsIndexList,
-                                                                   const iDynTree::VectorDynSize& upperBoundary,
-                                                                   const iDynTree::VectorDynSize& lowerBoundary,
-                                                                   const iDynTree::MatrixDynSize& customConstraintMatrix,
-                                                                   const double k_u,
-                                                                   const double k_l)
+
+bool DynamicalInverseKinematics::setLinearJointConfigurationLimits(
+    const std::vector<iDynTree::JointIndex>& jointsIndexList,
+    const iDynTree::VectorDynSize& upperBoundary,
+    const iDynTree::VectorDynSize& lowerBoundary,
+    const iDynTree::MatrixDynSize& customConstraintMatrix)
 {
     if (!pImpl->m_isModelLoaded)
         return false;
@@ -890,9 +892,15 @@ bool DynamicalInverseKinematics::setLinearJointConfigurationLimits(const std::ve
     pImpl->m_linearLimits.constraintMatrix = customConstraintMatrix;
     pImpl->m_linearLimits.constraintUpperBound = upperBoundary;
     pImpl->m_linearLimits.constraintLowerBound = lowerBoundary;
+
+    return true;
+}
+
+bool DynamicalInverseKinematics::setConstraintParametersJointValues(const double& k_u,
+                                                                    const double& k_l)
+{
     pImpl->m_linearLimits.k_u = k_u;
     pImpl->m_linearLimits.k_l = k_l;
-
     return true;
 }
 

--- a/HumanDynamicsEstimationLibrary/algorithms/src/InverseVelocityKinematics.cpp
+++ b/HumanDynamicsEstimationLibrary/algorithms/src/InverseVelocityKinematics.cpp
@@ -1404,14 +1404,19 @@ bool InverseVelocityKinematics::setCustomConstraintsJointsValues(
     const std::vector<iDynTree::JointIndex>& jointsIndexList,
     const iDynTree::VectorDynSize& upperBoundary,
     const iDynTree::VectorDynSize& lowerBoundary,
-    const iDynTree::MatrixDynSize& customConstraintMatrix,
-    const double k_u,
-    const double k_l)
+    const iDynTree::MatrixDynSize& customConstraintMatrix)
 {
     pImpl->m_custom_ConstraintVariablesIndex = jointsIndexList;
     pImpl->m_custom_ConstraintMatrix = customConstraintMatrix;
     pImpl->m_custom_ConstraintUpperBound = upperBoundary;
     pImpl->m_custom_ConstraintLowerBound = lowerBoundary;
+
+    return true;
+}
+
+bool InverseVelocityKinematics::setConstraintParametersJointValues(const double& k_u,
+                                                                   const double& k_l)
+{
     pImpl->m_k_u = k_u;
     pImpl->m_k_l = k_l;
     return true;

--- a/conf/xml/HumanStateProvider.xml
+++ b/conf/xml/HumanStateProvider.xml
@@ -35,7 +35,7 @@
         sparseCholeskyDecomposition,
         robustCholeskyDecomposition,
         sparseRobustCholeskyDecomposition -->
-        <param name='inverseVelocityKinematicsSolver'>sparseRobustCholeskyDecomposition</param>
+        <param name='inverseVelocityKinematicsSolver'>QP</param>
         <param name="linVelTargetWeight">1.0</param>
         <param name="angVelTargetWeight">1.0</param>
         <!-- integration based IK parameters -->
@@ -67,6 +67,49 @@
             <param name="map_LeftLowerLeg">(LeftLowerLeg, XsensSuit::vLink::LeftLowerLeg)</param>
             <param name="map_LeftFoot">(LeftFoot, XsensSuit::vLink::LeftFoot)</param>
             <param name="map_LeftToe">(LeftToe, XsensSuit::vLink::LeftToe)</param>
+        </group>
+        <group name="CUSTOM_CONSTRAINTS">
+        <!-- check issue https://github.com/robotology/human-dynamics-estimation/issues/132 for more info-->
+        <!-- note that a group can not be empty, otherwise it returns error-->
+        <!-- custom joint limits velocities-->
+            <!--param name="custom_joints_velocity_limits_names">(neck_roll, neck_pitch)</param-->
+            <param name="custom_joints_velocity_limits_names">()</param>
+            <!-- the upper bound is "+", while the lower bounds are "-" -->
+            <!--param name="custom_joints_velocity_limits_values">(10.0, 15.0)</param-->
+            <param name="custom_joints_velocity_limits_values">()</param>
+        <!-- **** base velocity limit: roll, pitch, yaw, x, y, z ****-->
+            <!--param name="base_velocity_limit_upper_buond">(1.0, 1.0, 1.0, 1.0, 1.0, 1.0 )</param>
+            <param name="base_velocity_limit_lower_buond">(-1.0, -1.0, -1.0, -1.0, -1.0, -1.0 )</param-->
+        <!-- Custom joint Configuration constraints-->
+        <!-- if the boudary value is inf, I will use -1000.0 rad, or +1000.0 rad-->
+        <!--param name="custom_constraint_variables">(
+        l_shoulder_pitch, l_shoulder_roll, l_shoulder_yaw, l_elbow, l_wrist_prosup,
+        r_shoulder_pitch, r_shoulder_roll, r_shoulder_yaw, r_elbow, r_wrist_prosup)</param>
+        <param name="custom_constraint_matrix"> (
+        (1.7105, -1.7105,  0.0,     0.0,    0.0,    0.0,     0.0,      0.0,       0.0,    0.0),
+        (1.7105, -1.7105,  -1.7105, 0.0,    0.0,    0.0,     0.0,      0.0,       0.0,    0.0),
+        (0.0,    1.0,      1.0,     0.0,    0.0,    0.0,     0.0,      0.0,       0.0,    0.0),
+        (0.0,    1.0,      0.0427,  0.0,    0.0,    0.0,     0.0,      0.0,       0.0,    0.0),
+        (0.0,    1.0,      0.0,     0.0,    0.0,    0.0,     0.0,      0.0,       0.0,    0.0),
+        (0.0,    0.0,      0.0,     2.5,    1.0,    0.0,     0.0,      0.0,       0.0,    0.0),
+        (0.0,    0.0,      0.0,     -2.5,   1.0,    0.0,     0.0,      0.0,       0.0,    0.0),
+        (0.0,    0.0,      0.0,     0.0,    0.0,    1.7105,  -1.7105,  0.0,       0.0,    0.0),
+        (0.0,    0.0,      0.0,     0.0,    0.0,    1.7105,  -1.7105,  -1.7105,   0.0,    0.0,),
+        (0.0,    0.0,      0.0,     0.0,    0.0,    0.0,     1.0,       1.0,      0.0,    0.0,),
+        (0.0,    0.0,      0.0,     0.0,    0.0,    0.0,     1.0,       0.0427,   0.0,    0.0,),
+        (0.0,    0.0,      0.0,     0.0,    0.0,    0.0,     1.0,       0.0,      0.0,    0.0,),
+        (0.0,    0.0,      0.0,     0.0,    0.0,    0.0,     0.0,       0.0,      2.5,    1.0,),
+        (0.0,    0.0,      0.0,     0.0,    0.0,    0.0,     0.0,       0.0,      -2.5,   1.0,),
+        )</param>
+        <param name="custom_constraint_lower_bound"> (
+        -6.0563,  -6.3979,  -1.1623,  0.4611,  -1000.0,  -1000.0,  -5.2796,
+        -6.0563,  -6.3979,  -1.1623,  0.4611,  -1000.0,  -1000.0,  -5.2796)</param>
+        <param name="custom_constraint_upper_bound"> (
+        1000.0,  1.9622,  3.7228,  1000.0,  1.7453,  5.2796,  1000.0,
+        1000.0,  1.9622,  3.7228,  1000.0,  1.7453,  5.2796,  1000.0)</param-->
+            <!-- The following two parameters should be set always , if not set they are by default 0.5 -->
+            <param name="k_u">0.5</param>
+            <param name="k_l">0.5</param>
         </group>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -1937,7 +1937,11 @@ bool HumanStateProvider::impl::initializeDynamicalInverseKinematicsSolver()
         yError() << LogPrefix << "Failed to set all joints velocity limits";
         return false;
     }
-    
+
+    if (!dynamicalInverseKinematics.setConstraintParametersJointValues(k_u, k_l))
+        return false;
+
+
     if (custom_jointsVelocityLimitsNames.size() != 0) {
         for (size_t i = 0; i < custom_jointsVelocityLimitsNames.size(); i++) {
             if (!dynamicalInverseKinematics.setJointVelocityLimit(custom_jointsVelocityLimitsIndexes[i],
@@ -1959,12 +1963,11 @@ bool HumanStateProvider::impl::initializeDynamicalInverseKinematicsSolver()
     }
 
     if (customConstraintVariablesIndex.size() != 0) {
-        if (!dynamicalInverseKinematics.setLinearJointConfigurationLimits(customConstraintVariablesIndex,
-                                                                          customConstraintUpperBound,
-                                                                          customConstraintLowerBound,
-                                                                          customConstraintMatrix,
-                                                                          k_u,
-                                                                          k_l))
+        if (!dynamicalInverseKinematics.setLinearJointConfigurationLimits(
+                customConstraintVariablesIndex,
+                customConstraintUpperBound,
+                customConstraintLowerBound,
+                customConstraintMatrix))
             return false;
     }
 


### PR DESCRIPTION
With this PR, I am fixing the problem related to the QP that returns zero values as the solution.
reference issue: https://github.com/robotology/human-dynamics-estimation/issues/167

The format of the files updated are set to clang format.