### PR TITLE
Fix C1128 error when compiling on MSVC in Debug mode

### DIFF
--- a/HumanDynamicsEstimationLibrary/algorithms/CMakeLists.txt
+++ b/HumanDynamicsEstimationLibrary/algorithms/CMakeLists.txt
@@ -18,3 +18,7 @@ add_component(NAME algorithms
                                      osqp::osqp
                                      HumanDynamicsEstimation::utils
              )
+
+if(MSVC)
+  target_compile_options(algorithms PRIVATE /bigobj)
+endif()


### PR DESCRIPTION
The `InverseVelocityKinematics.cpp` is quite big, and in certain condition (for example Debug compilation) in MSVC its compilation fails with error:
~~~
2022-02-25T19:52:11.1221049Z C:\robotology-superbuild\src\HumanDynamicsEstimation\HumanDynamicsEstimationLibrary\algorithms\src\InverseVelocityKinematics.cpp : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj [C:\robotology-superbuild\build\src\HumanDynamicsEstimation\HumanDynamicsEstimationLibrary\algorithms\algorithms.vcxproj] [C:\robotology-superbuild\build\HumanDynamicsEstimation.vcxproj]
~~~

The suggested fix is to add the `/bigobj` option, that is harmless as it just break compatibility with VS2005 linker (see https://stackoverflow.com/questions/15110580/penalty-of-the-msvs-compiler-flag-bigobj), that however it is not a use case we are interested in. 

This was already done in https://github.com/robotology/human-dynamics-estimation/pull/174, but then the  `InverseVelocityKinematics.cpp` file was move to another target so the option needs to be added to that target as well. 

@RiccardoGrieco @lrapetti it would be great to have a 2.4.1 once this is merged, so that we could include this in the v2022.02.0 distro without other workarounds (see P3 in https://github.com/robotology/robotology-superbuild/issues/1046). This also have the convenient side-effect to also include https://github.com/robotology/human-dynamics-estimation/pull/279 in a release.