### PR TITLE
Add parameter for setting all the position scaling factors at once

### DIFF
--- a/conf/xml/RobotStateProvider_iCub2_5_openxr_ifeel.xml
+++ b/conf/xml/RobotStateProvider_iCub2_5_openxr_ifeel.xml
@@ -101,6 +101,9 @@
             <param name="target_Head">( 0.7 0.7 0.6 )</param>
             <param name="target_LeftHand">( 0.7 0.7 0.6 )</param>
             <param name="target_RightHand">( 0.7 0.7 0.6 )</param>
+            <param name="x_scale_factor_all" extern-name="xy_scale">0.7</param>
+            <param name="y_scale_factor_all" extern-name="xy_scale">0.7</param>
+            <param name="z_scale_factor_all" extern-name="z_scale">0.6</param>
         </group>
         <group name="CUSTOM_CONSTRAINTS">
         <!-- check issue https://github.com/robotology/human-dynamics-estimation/issues/132 for more info-->

--- a/conf/xml/RobotStateProvider_iCub3_openxr_ifeel.xml
+++ b/conf/xml/RobotStateProvider_iCub3_openxr_ifeel.xml
@@ -98,6 +98,9 @@
             <param name="target_Head">( 0.7 0.7 0.6 )</param>
             <param name="target_LeftHand">( 0.7 0.7 0.6 )</param>
             <param name="target_RightHand">( 0.7 0.7 0.6 )</param>
+            <param name="x_scale_factor_all" extern-name="xy_scale">0.7</param>
+            <param name="y_scale_factor_all" extern-name="xy_scale">0.7</param>
+            <param name="z_scale_factor_all" extern-name="z_scale">0.6</param>
         </group>
         <group name="CUSTOM_CONSTRAINTS">
         <!-- check issue https://github.com/robotology/human-dynamics-estimation/issues/132 for more info-->


### PR DESCRIPTION
This PR adds the possibility to use a single parameter (`x_scale_factor_all`,`y_scale_factor_all`,`z_scale_factor_all `) for the position scale factors for all the targets.

In this way, until https://github.com/robotology/yarp/issues/2812 is not fixed, the scale factors can be passed via command line (as long as we want to set them to the same value for all the targets). 
I have also added the `extern-name` option in the [RobotStateProvider_iCub2_5_openxr_ifeel.xml](https://github.com/robotology/human-dynamics-estimation/compare/xprize...add-scaleFactorAll-flag?expand=1#diff-dc42fd4f001c52fc080e027c8397b453e5817fa76d96e7561ecf82bd440245c1) configuration so that we can set then as:
```sh
yarprobotinterface --config RobotStateProvider_iCub2_5_openxr_ifeel.xml --xy_scale $SCALE_FOR_XY --z_scale $SCALE_FOR_Z
```