### PR TITLE
[HDELibrary] Expose target error norms in Dynamical Inverse Kinematics 

### DIFF
--- a/HumanDynamicsEstimationLibrary/algorithms/include/hde/algorithms/DynamicalInverseKinematics.hpp
+++ b/HumanDynamicsEstimationLibrary/algorithms/include/hde/algorithms/DynamicalInverseKinematics.hpp
@@ -202,6 +202,9 @@ public:
     void clearProblem();
 
     bool solve(const double dt);
+
+    double getTargetsMeanOrientationErrorNorm() const;
+    double getTargetsMeanPositionErrorNorm() const;
 };
 
 #endif // DYNAMICALINVERSEKINEMATICS_HPP


### PR DESCRIPTION
This PR exposes the mean error norm computed for all the rotation and position targets in Dynamical IK.

P.S. my IDE editor automatically removed the blank spaces in the files. Let me know if these changes on the blank spaces need to be reverted.

cc @lrapetti 