### PR TITLE
Fix deprecated `yarp` and `iDynTree` methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ env:
     vcpkg_robotology_TAG: v0.6.0
     YCM_TAG: v0.13.0
     YARP_TAG: v3.6.0
-    iDynTree_TAG: v4.2.0 
-    wearables_TAG: v1.2.2 
+    iDynTree_TAG: v5.1.0 
+    wearables_TAG: v1.3.0 
     icub_main_TAG: v1.21.0    
     osqp_TAG: v0.6.0
     OsqpEigen_TAG: v0.6.2

--- a/devices/HumanControlBoard/HumanControlBoard.cpp
+++ b/devices/HumanControlBoard/HumanControlBoard.cpp
@@ -78,7 +78,7 @@ bool HumanControlBoard::open(yarp::os::Searchable& config)
     // CHECK THE CONFIGURATION OPTIONS
     // ===============================
 
-    if (!(config.check("period") && config.find("period").isDouble())) {
+    if (!(config.check("period") && config.find("period").isFloat64())) {
         yInfo() << LogPrefix << "Using default period:" << DefaultPeriod << "s";
     }
 
@@ -91,7 +91,7 @@ bool HumanControlBoard::open(yarp::os::Searchable& config)
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================
 
-    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asDouble();
+    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
     const std::string urdfFileName = config.find("urdf").asString();
 
     // ==========================

--- a/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.cpp
+++ b/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.cpp
@@ -67,7 +67,7 @@ static bool parseYarpValueToStdVector(const yarp::os::Value& option, std::vector
                 return false;
             }
 
-            output.push_back(option.asList()->get(i).asDouble());
+            output.push_back(option.asList()->get(i).asFloat64());
         }
     }
     else if (isDouble) {
@@ -244,7 +244,7 @@ static bool getTripletsFromPriorGroupCase1Case2(const yarp::os::Value& covMeasur
                                                 const std::string& sensorType,
                                                 iDynTree::Triplets& triplets)
 {
-    if (covMeasurementOption.isDouble()) {
+    if (covMeasurementOption.isFloat64()) {
         std::vector<double> covValues;
         covValues.push_back(covMeasurementOption.asFloat64());
 
@@ -377,7 +377,7 @@ static bool getTripletsFromPriorGroup(const yarp::os::Bottle priorGroup,
 
             // This check allows sharing the same getTripletsFromPriorGroupCase1Case2 function
             // for parsing Case 3
-            if (!covMeasurementOfSpecificElement.isDouble()
+            if (!covMeasurementOfSpecificElement.isFloat64()
                 && !(covMeasurementOfSpecificElement.isList()
                      && (covMeasurementOfSpecificElement.asList()->size() > 0))) {
                 yError() << LogPrefix << "The specific elements for"
@@ -822,7 +822,7 @@ bool HumanDynamicsEstimator::open(yarp::os::Searchable& config)
         return false;
     }
 
-    if (!(config.check("number_of_wrench_sensors") && config.find("number_of_wrench_sensors").isInt())) {
+    if (!(config.check("number_of_wrench_sensors") && config.find("number_of_wrench_sensors").isInt32())) {
         yError() << LogPrefix << "Parameter 'number_of_wrench_sensors' missing or invalid";
         return false;
     }
@@ -839,7 +839,7 @@ bool HumanDynamicsEstimator::open(yarp::os::Searchable& config)
     double period = config.find("period").asFloat64();
     std::string urdfFileName = config.find("urdf").asString();
     std::string baseLink = config.find("baseLink").asString();
-    int number_of_wrench_sensors = config.find("number_of_wrench_sensors").asInt();
+    int number_of_wrench_sensors = config.find("number_of_wrench_sensors").asInt32();
     yarp::os::Bottle* linkNames = config.find("wrench_sensors_link_name").asList();
 
     if (number_of_wrench_sensors != linkNames->size()) {

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -356,11 +356,11 @@ public:
                 response.addString("Entered command <calibrate> is correct, trying to set offset calibration for the link " + this->parentLinkName);
                 this->cmdStatus = rpcCommand::calibrate;
             }
-            else if (command.get(0).asString() == "setRotationOffset" && !command.get(1).isNull() && command.get(2).isDouble() && command.get(3).isDouble() && command.get(4).isDouble()) {
+            else if (command.get(0).asString() == "setRotationOffset" && !command.get(1).isNull() && command.get(2).isFloat64() && command.get(3).isFloat64() && command.get(4).isFloat64()) {
                 this->parentLinkName = command.get(1).asString();
-                this->roll = command.get(2).asDouble();
-                this->pitch = command.get(3).asDouble();
-                this->yaw = command.get(4).asDouble();
+                this->roll = command.get(2).asFloat64();
+                this->pitch = command.get(3).asFloat64();
+                this->yaw = command.get(4).asFloat64();
                 response.addString("Entered command <calibrate> is correct, trying to set rotation offset for the link " + this->parentLinkName);
                 this->cmdStatus = rpcCommand::setRotationOffset;
             }
@@ -509,15 +509,15 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
 
             // check if FIXED_SENSOR_ROTATION matrix is passed (9 elements)
             if (!(    (listContent->size() == 9)
-                   && (listContent->get(0).isDouble())
-                   && (listContent->get(1).isDouble())
-                   && (listContent->get(2).isDouble())
-                   && (listContent->get(3).isDouble())
-                   && (listContent->get(4).isDouble())
-                   && (listContent->get(5).isDouble())
-                   && (listContent->get(6).isDouble())
-                   && (listContent->get(7).isDouble())
-                   && (listContent->get(8).isDouble()) )) {
+                   && (listContent->get(0).isFloat64())
+                   && (listContent->get(1).isFloat64())
+                   && (listContent->get(2).isFloat64())
+                   && (listContent->get(3).isFloat64())
+                   && (listContent->get(4).isFloat64())
+                   && (listContent->get(5).isFloat64())
+                   && (listContent->get(6).isFloat64())
+                   && (listContent->get(7).isFloat64())
+                   && (listContent->get(8).isFloat64()) )) {
                 yError() << LogPrefix << "FIXED_SENSOR_ROTATION " << linkName << " must have 9 double values describing the rotation matrix";
                 return false;
             }
@@ -563,15 +563,15 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         std::string modelLinkName = fixedRotationGroup.get(i).asList()->get(0).asString();
         yarp::os::Bottle* fixedRotationMatrixValues = fixedRotationGroup.get(i).asList()->get(1).asList();
 
-        iDynTree::Rotation fixedRotation = iDynTree::Rotation( fixedRotationMatrixValues->get(0).asDouble(),
-                                                               fixedRotationMatrixValues->get(1).asDouble(),
-                                                               fixedRotationMatrixValues->get(2).asDouble(),
-                                                               fixedRotationMatrixValues->get(3).asDouble(),
-                                                               fixedRotationMatrixValues->get(4).asDouble(),
-                                                               fixedRotationMatrixValues->get(5).asDouble(),
-                                                               fixedRotationMatrixValues->get(6).asDouble(),
-                                                               fixedRotationMatrixValues->get(7).asDouble(),
-                                                               fixedRotationMatrixValues->get(8).asDouble());
+        iDynTree::Rotation fixedRotation = iDynTree::Rotation( fixedRotationMatrixValues->get(0).asFloat64(),
+                                                               fixedRotationMatrixValues->get(1).asFloat64(),
+                                                               fixedRotationMatrixValues->get(2).asFloat64(),
+                                                               fixedRotationMatrixValues->get(3).asFloat64(),
+                                                               fixedRotationMatrixValues->get(4).asFloat64(),
+                                                               fixedRotationMatrixValues->get(5).asFloat64(),
+                                                               fixedRotationMatrixValues->get(6).asFloat64(),
+                                                               fixedRotationMatrixValues->get(7).asFloat64(),
+                                                               fixedRotationMatrixValues->get(8).asFloat64());
 
         pImpl->fixedSensorRotation.emplace(modelLinkName, fixedRotation);
         yInfo() << LogPrefix << "Adding Fixed Rotation for " << modelLinkName << "==>" << fixedRotation.toString();
@@ -587,7 +587,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
             yError() << LogPrefix << "allowFailures option not found or not valid";
             return false;
         }
-        if (!(config.check("maxIterationsIK") && config.find("maxIterationsIK").isInt())) {
+        if (!(config.check("maxIterationsIK") && config.find("maxIterationsIK").isInt32())) {
             yError() << LogPrefix << "maxIterationsIK option not found or not valid";
             return false;
         }
@@ -609,18 +609,18 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
             yError() << LogPrefix << "rotTargetWeight option not found or not valid";
             return false;
         }
-        if (!(config.check("costRegularization") && config.find("costRegularization").isDouble())) {
+        if (!(config.check("costRegularization") && config.find("costRegularization").isFloat64())) {
             yError() << LogPrefix << "costRegularization option not found or not valid";
             return false;
         }
 
         pImpl->allowIKFailures = config.find("allowIKFailures").asBool();
-        pImpl->maxIterationsIK = config.find("maxIterationsIK").asInt();
+        pImpl->maxIterationsIK = config.find("maxIterationsIK").asInt32();
         pImpl->costTolerance = config.find("costTolerance").asFloat64();
         pImpl->linearSolverName = config.find("ikLinearSolver").asString();
         pImpl->posTargetWeight = config.find("posTargetWeight").asFloat64();
         pImpl->rotTargetWeight = config.find("rotTargetWeight").asFloat64();
-        pImpl->costRegularization = config.find("costRegularization").asDouble();
+        pImpl->costRegularization = config.find("costRegularization").asFloat64();
     }
 
     if (pImpl->ikSolver == SolverIK::global || pImpl->ikSolver == SolverIK::dynamical) {
@@ -654,13 +654,13 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         pImpl->useDirectBaseMeasurement = config.find("useDirectBaseMeasurement").asBool();
         pImpl->linVelTargetWeight = config.find("linVelTargetWeight").asFloat64();
         pImpl->angVelTargetWeight = config.find("angVelTargetWeight").asFloat64();
-        pImpl->costRegularization = config.find("costRegularization").asDouble();
+        pImpl->costRegularization = config.find("costRegularization").asFloat64();
     }
 
     if (pImpl->ikSolver == SolverIK::pairwised) {
         if (!(config.check("ikPoolSizeOption")
               && (config.find("ikPoolSizeOption").isString()
-                  || config.find("ikPoolSizeOption").isInt()))) {
+                  || config.find("ikPoolSizeOption").isInt32()))) {
             yError() << LogPrefix << "ikPoolOption option not found or not valid";
             return false;
         }
@@ -672,8 +672,8 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
                     << " available logical threads for ik pool";
             pImpl->ikPoolSize = static_cast<int>(std::thread::hardware_concurrency());
         }
-        else if (config.find("ikPoolSizeOption").isInt()) {
-            pImpl->ikPoolSize = config.find("ikPoolSizeOption").asInt();
+        else if (config.find("ikPoolSizeOption").isInt32()) {
+            pImpl->ikPoolSize = config.find("ikPoolSizeOption").asInt32();
         }
 
         // The pairwised IK will always use the measured base pose and velocity for the base link
@@ -708,9 +708,9 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         }
 
         if (config.check("dynamicalIKJointVelocityLimit")
-            && config.find("dynamicalIKJointVelocityLimit").isDouble()) {
+            && config.find("dynamicalIKJointVelocityLimit").isFloat64()) {
             pImpl->dynamicalIKJointVelocityLimit =
-                config.find("dynamicalIKJointVelocityLimit").asDouble();
+                config.find("dynamicalIKJointVelocityLimit").asFloat64();
         }
         else {
             pImpl->dynamicalIKJointVelocityLimit =
@@ -913,7 +913,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
                 pImpl->custom_jointsVelocityLimitsValues.resize(constraintListContent->size());
                 for (size_t i = 0; i < constraintListContent->size(); i++) {
                     pImpl->custom_jointsVelocityLimitsValues.setVal(
-                        i, constraintListContent->get(i).asDouble());
+                        i, constraintListContent->get(i).asFloat64());
                 }
                 yInfo() << "custom_joints_velocity_limits_values: ";
                 for (size_t i = 0; i < pImpl->custom_jointsVelocityLimitsValues.size(); i++) {
@@ -940,7 +940,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
                                                              innerLoop->size());
                     }
                     for (size_t j = 0; j < innerLoop->size(); j++) {
-                        pImpl->customConstraintMatrix.setVal(i, j, innerLoop->get(j).asDouble());
+                        pImpl->customConstraintMatrix.setVal(i, j, innerLoop->get(j).asFloat64());
                     }
                 }
                 yInfo() << "Constraint matrix: ";
@@ -956,7 +956,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
                 pImpl->customConstraintUpperBound.resize(constraintListContent->size());
                 for (size_t i = 0; i < constraintListContent->size(); i++) {
                     pImpl->customConstraintUpperBound.setVal(
-                        i, constraintListContent->get(i).asDouble());
+                        i, constraintListContent->get(i).asFloat64());
                 }
                 yInfo() << "custom_constraint_upper_bound: ";
                 for (size_t i = 0; i < pImpl->customConstraintUpperBound.size(); i++) {
@@ -967,7 +967,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
                 pImpl->customConstraintLowerBound.resize(constraintListContent->size());
                 for (size_t i = 0; i < constraintListContent->size(); i++) {
                     pImpl->customConstraintLowerBound.setVal(
-                        i, constraintListContent->get(i).asDouble());
+                        i, constraintListContent->get(i).asFloat64());
                 }
                 yInfo() << "custom_constraint_lower_bound: ";
                 for (size_t i = 0; i < pImpl->customConstraintLowerBound.size(); i++) {
@@ -982,7 +982,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
                 pImpl->baseVelocityUpperLimit.resize(6);
                 for (size_t i = 0; i < constraintListContent->size(); i++) {
                     pImpl->baseVelocityUpperLimit.setVal(i,
-                                                         constraintListContent->get(i).asDouble());
+                                                         constraintListContent->get(i).asFloat64());
                 }
                 yInfo() << "base_velocity_limit_upper_buond: ";
                 for (size_t i = 0; i < pImpl->baseVelocityUpperLimit.size(); i++) {
@@ -997,7 +997,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
                 pImpl->baseVelocityLowerLimit.resize(6);
                 for (size_t i = 0; i < constraintListContent->size(); i++) {
                     pImpl->baseVelocityLowerLimit.setVal(i,
-                                                         constraintListContent->get(i).asDouble());
+                                                         constraintListContent->get(i).asFloat64());
                 }
                 yInfo() << "base_velocity_limit_lower_buond: ";
                 for (size_t i = 0; i < pImpl->baseVelocityLowerLimit.size(); i++) {
@@ -1005,14 +1005,14 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
                 }
             } // another option
             else if (constraintKey == "k_u") {
-                if (constraintGroup.check("k_u") && constraintGroup.find("k_u").isDouble()) {
-                    pImpl->k_u = constraintGroup.find("k_u").asDouble();
+                if (constraintGroup.check("k_u") && constraintGroup.find("k_u").isFloat64()) {
+                    pImpl->k_u = constraintGroup.find("k_u").asFloat64();
                     yInfo() << "k_u: " << pImpl->k_u;
                 }
             } // another option
             else if (constraintKey == "k_l") {
-                if (constraintGroup.check("k_l") && constraintGroup.find("k_l").isDouble()) {
-                    pImpl->k_l = constraintGroup.find("k_l").asDouble();
+                if (constraintGroup.check("k_l") && constraintGroup.find("k_l").isFloat64()) {
+                    pImpl->k_l = constraintGroup.find("k_l").asFloat64();
                     yInfo() << "k_l: " << pImpl->k_l;
                 }
             } // another option

--- a/devices/HumanWrenchProvider/HumanWrenchProvider.cpp
+++ b/devices/HumanWrenchProvider/HumanWrenchProvider.cpp
@@ -114,15 +114,15 @@ bool parseRotation(yarp::os::Bottle* list, iDynTree::Rotation& rotation)
         return false;
     }
 
-    rotation = iDynTree::Rotation(list->get(0).asDouble(),
-                                  list->get(1).asDouble(),
-                                  list->get(2).asDouble(),
-                                  list->get(3).asDouble(),
-                                  list->get(4).asDouble(),
-                                  list->get(5).asDouble(),
-                                  list->get(6).asDouble(),
-                                  list->get(7).asDouble(),
-                                  list->get(8).asDouble());
+    rotation = iDynTree::Rotation(list->get(0).asFloat64(),
+                                  list->get(1).asFloat64(),
+                                  list->get(2).asFloat64(),
+                                  list->get(3).asFloat64(),
+                                  list->get(4).asFloat64(),
+                                  list->get(5).asFloat64(),
+                                  list->get(6).asFloat64(),
+                                  list->get(7).asFloat64(),
+                                  list->get(8).asFloat64());
     return true;
 }
 
@@ -134,7 +134,7 @@ bool parsePosition(yarp::os::Bottle* list, iDynTree::Position& position)
     }
 
     position = iDynTree::Position(
-        list->get(0).asDouble(), list->get(1).asDouble(), list->get(2).asDouble());
+        list->get(0).asFloat64(), list->get(1).asFloat64(), list->get(2).asFloat64());
     return true;
 }
 
@@ -249,7 +249,7 @@ bool HumanWrenchProvider::open(yarp::os::Searchable& config)
     // INITIALIZE THE WRENCH SOURCES
     // =============================
 
-    if (!(config.check("number_of_sources") && config.find("number_of_sources").asInt())) {
+    if (!(config.check("number_of_sources") && config.find("number_of_sources").asInt32())) {
         yError() << LogPrefix << "Option 'number_of_sources' not found or not a valid Integer";
         return false;
     }
@@ -263,7 +263,7 @@ bool HumanWrenchProvider::open(yarp::os::Searchable& config)
     std::vector<std::string> sourcesNames;
 
     // Check the number of sources are correct
-    if ( config.find("number_of_sources").asInt() != listOfSources->size()) {
+    if ( config.find("number_of_sources").asInt32() != listOfSources->size()) {
         yError() << LogPrefix << " 'number_of_sources' and 'sources' list provided are not matching";
         return false;
     }

--- a/devices/RobotPositionController/RobotPositionController.cpp
+++ b/devices/RobotPositionController/RobotPositionController.cpp
@@ -90,19 +90,19 @@ bool RobotPositionController::open(yarp::os::Searchable& config)
     // CHECK THE CONFIGURATION OPTIONS
     // ===============================
 
-    if (!(config.check("period") && config.find("period").isDouble())) {
+    if (!(config.check("period") && config.find("period").isFloat64())) {
         yInfo() << LogPrefix << "Using default period:" << DefaultPeriod << "s";
     }
 
-    if (!(config.check("refSpeed") && config.find("refSpeed").isDouble())) {
+    if (!(config.check("refSpeed") && config.find("refSpeed").isFloat64())) {
         yError() << LogPrefix << "refSpeed option not found or not valid";
     }
 
-    if (!(config.check("samplingTime") && config.find("samplingTime").isDouble())) {
+    if (!(config.check("samplingTime") && config.find("samplingTime").isFloat64())) {
         yError() << LogPrefix << "samplingTime option not found or not valid";
     }
 
-    if (!(config.check("smoothingTime") && config.find("smoothingTime").isDouble())) {
+    if (!(config.check("smoothingTime") && config.find("smoothingTime").isFloat64())) {
         yError() << LogPrefix << "smoothingTime option not found or not valid";
     }
 
@@ -130,11 +130,11 @@ bool RobotPositionController::open(yarp::os::Searchable& config)
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================
 
-    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asDouble();
+    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
     pImpl->controlMode = config.find("controlMode").asString();
-    pImpl->refSpeed = config.find("refSpeed").asDouble();
-    pImpl->samplingTime = config.find("samplingTime").asDouble();
-    pImpl->smoothingTime = config.find("smoothingTime").asDouble();
+    pImpl->refSpeed = config.find("refSpeed").asFloat64();
+    pImpl->samplingTime = config.find("samplingTime").asFloat64();
+    pImpl->smoothingTime = config.find("smoothingTime").asFloat64();
     pImpl->initialSmoothingCount = 0;
     yarp::os::Bottle* controlBoardsList = config.find("controlBoardsList").asList();
     const std::string remotePrefix  = config.find("remotePrefix").asString();
@@ -142,20 +142,20 @@ bool RobotPositionController::open(yarp::os::Searchable& config)
 
     if (pImpl->controlMode == "positionDirect")
     {
-        if (!(config.check("initialSmoothingTime") && config.find("initialSmoothingTime").isDouble())) {
+        if (!(config.check("initialSmoothingTime") && config.find("initialSmoothingTime").isFloat64())) {
             yInfo() << LogPrefix << "initialSmoothingTime option not found or not valid, using default value of 2.5 Seconds";
             pImpl->initialSmoothingTime = 2.5;
         }
         else {
-            pImpl->initialSmoothingTime = config.find("initialSmoothingTime").asDouble();
+            pImpl->initialSmoothingTime = config.find("initialSmoothingTime").asFloat64();
         }
 
-        if (!(config.check("maxSmoothingCount") && config.find("maxSmoothingCount").isInt())) {
+        if (!(config.check("maxSmoothingCount") && config.find("maxSmoothingCount").isInt32())) {
             yInfo() << LogPrefix << "initialSmoothingCount option not found or not valid, using default value of 5000";
             pImpl->maxSmoothingCount = 5000;
         }
         else {
-            pImpl->maxSmoothingCount = config.find("maxSmoothingCount").asInt();
+            pImpl->maxSmoothingCount = config.find("maxSmoothingCount").asInt32();
         }
     }
 

--- a/modules/HumanStateVisualizer/CMakeLists.txt
+++ b/modules/HumanStateVisualizer/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(${EXE_TARGET_NAME} LINK_PUBLIC
   YARP::YARP_dev
   YARP::YARP_init
   iDynTree::idyntree-core
-  iDynTree::idyntree-modelio-urdf
+  iDynTree::idyntree-modelio
   iDynTree::idyntree-visualization
   IHumanState)
 

--- a/modules/HumanStateVisualizer/src/main.cpp
+++ b/modules/HumanStateVisualizer/src/main.cpp
@@ -115,12 +115,12 @@ int main(int argc, char* argv[])
     }
     for (size_t idx = 0; idx < 3; idx++)
     {
-        if ( !(rf.find("cameraDeltaPosition").asList()->get(idx).isDouble()) )
+        if ( !(rf.find("cameraDeltaPosition").asList()->get(idx).isFloat64()) )
         {
             yError() << LogPrefix << "'cameraDeltaPosition' entry [ " << idx << " ] is not valid.";
             return EXIT_FAILURE;
         }
-        cameraDeltaPosition.setVal(idx, rf.find("cameraDeltaPosition").asList()->get(idx).asDouble());
+        cameraDeltaPosition.setVal(idx, rf.find("cameraDeltaPosition").asList()->get(idx).asFloat64());
     }
 
     if( !(rf.check("useFixedCamera") && rf.find("useFixedCamera").isBool()) ) 
@@ -140,21 +140,21 @@ int main(int argc, char* argv[])
         }
         for (size_t idx = 0; idx < 3; idx++)
         {
-            if ( !(rf.find("fixedCameraTarget").asList()->get(idx).isDouble()) )
+            if ( !(rf.find("fixedCameraTarget").asList()->get(idx).isFloat64()) )
             {
                 yError() << LogPrefix << "'fixedCameraTarget' entry [ " << idx << " ] is not valid.";
                 return EXIT_FAILURE;
             }
-            fixedCameraTarget.setVal(idx, rf.find("fixedCameraTarget").asList()->get(idx).asDouble());
+            fixedCameraTarget.setVal(idx, rf.find("fixedCameraTarget").asList()->get(idx).asFloat64());
         }
     }
 
-    if( !(rf.check("maxVisualizationFPS") && rf.find("maxVisualizationFPS").isInt() && rf.find("maxVisualizationFPS").asInt() > 0) ) 
+    if( !(rf.check("maxVisualizationFPS") && rf.find("maxVisualizationFPS").isInt32() && rf.find("maxVisualizationFPS").asInt32() > 0) ) 
     {
         yError() << LogPrefix << "'maxVisualizationFPS' option not found or not valid.";
         return EXIT_FAILURE;
     }
-    unsigned int maxVisualizationFPS = rf.find("maxVisualizationFPS").asInt();
+    unsigned int maxVisualizationFPS = rf.find("maxVisualizationFPS").asInt32();
 
     if( !(rf.check("humanStateDataPortName") && rf.find("humanStateDataPortName").isString()) ) 
     {
@@ -204,12 +204,12 @@ int main(int argc, char* argv[])
     double forceScalingFactor;
     if (visualizeWrenches)
     {
-        if ( !(rf.check("forceScalingFactor") && rf.find("forceScalingFactor").isDouble()) )
+        if ( !(rf.check("forceScalingFactor") && rf.find("forceScalingFactor").isFloat64()) )
         {
             yError() << LogPrefix << "'forceScalingFactor' option not found or not valid.";
             return EXIT_FAILURE;
         }
-        forceScalingFactor = rf.find("forceScalingFactor").asDouble();
+        forceScalingFactor = rf.find("forceScalingFactor").asFloat64();
     }
 
     // load model

--- a/publishers/HumanDynamicsPublisher/CMakeLists.txt
+++ b/publishers/HumanDynamicsPublisher/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(HumanDynamicsPublisher PUBLIC
     YARP::YARP_dev
     YARP::YARP_init
     YARP::YARP_rosmsg
-    iDynTree::idyntree-modelio-urdf)
+    iDynTree::idyntree-modelio)
 
 yarp_install(
     TARGETS HumanDynamicsPublisher

--- a/publishers/HumanRobotPosePublisher/HumanRobotPosePublisher.cpp
+++ b/publishers/HumanRobotPosePublisher/HumanRobotPosePublisher.cpp
@@ -130,15 +130,15 @@ bool parseRotation(yarp::os::Bottle* list, iDynTree::Rotation& rotation)
         return false;
     }
 
-    rotation = iDynTree::Rotation(list->get(0).asDouble(),
-                                  list->get(1).asDouble(),
-                                  list->get(2).asDouble(),
-                                  list->get(3).asDouble(),
-                                  list->get(4).asDouble(),
-                                  list->get(5).asDouble(),
-                                  list->get(6).asDouble(),
-                                  list->get(7).asDouble(),
-                                  list->get(8).asDouble());
+    rotation = iDynTree::Rotation(list->get(0).asFloat64(),
+                                  list->get(1).asFloat64(),
+                                  list->get(2).asFloat64(),
+                                  list->get(3).asFloat64(),
+                                  list->get(4).asFloat64(),
+                                  list->get(5).asFloat64(),
+                                  list->get(6).asFloat64(),
+                                  list->get(7).asFloat64(),
+                                  list->get(8).asFloat64());
     return true;
 }
 
@@ -150,7 +150,7 @@ bool parsePosition(yarp::os::Bottle* list, iDynTree::Position& position)
     }
 
     position = iDynTree::Position(
-        list->get(0).asDouble(), list->get(1).asDouble(), list->get(2).asDouble());
+        list->get(0).asFloat64(), list->get(1).asFloat64(), list->get(2).asFloat64());
     return true;
 }
 

--- a/wrappers/HumanDynamicsWrapper/HumanDynamicsWrapper.cpp
+++ b/wrappers/HumanDynamicsWrapper/HumanDynamicsWrapper.cpp
@@ -43,7 +43,7 @@ bool HumanDynamicsWrapper::open(yarp::os::Searchable& config)
     // CHECK THE CONFIGURATION OPTIONS
     // ===============================
 
-    if (!(config.check("period") && config.find("period").isDouble())) {
+    if (!(config.check("period") && config.find("period").isFloat64())) {
         yInfo() << LogPrefix << "Using default period:" << DefaultPeriod << "s";
     }
 
@@ -56,7 +56,7 @@ bool HumanDynamicsWrapper::open(yarp::os::Searchable& config)
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================
 
-    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asDouble();
+    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
     std::string outputPortName = config.find("outputPort").asString();
 
     // =============

--- a/wrappers/HumanStateWrapper/HumanStateWrapper.cpp
+++ b/wrappers/HumanStateWrapper/HumanStateWrapper.cpp
@@ -51,7 +51,7 @@ bool HumanStateWrapper::open(yarp::os::Searchable& config)
     // CHECK THE CONFIGURATION OPTIONS
     // ===============================
 
-    if (!(config.check("period") && config.find("period").isDouble())) {
+    if (!(config.check("period") && config.find("period").isFloat64())) {
         yInfo() << LogPrefix << "Using default period:" << DefaultPeriod << "s";
     }
 
@@ -64,7 +64,7 @@ bool HumanStateWrapper::open(yarp::os::Searchable& config)
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================
 
-    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asDouble();
+    double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
     std::string outputPortName = config.find("outputPort").asString();
 
     // =============


### PR DESCRIPTION
Removing deprecated methods from `YARP` and `iDynTree` (fixing https://github.com/robotology/human-dynamics-estimation/issues/296)