### PR TITLE
Update yarp version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 env:
     vcpkg_robotology_TAG: v0.6.0
     YCM_TAG: v0.14.1
-    YARP_TAG: v3.7.0
+    YARP_TAG: v3.7.1
     iDynTree_TAG: v5.1.0 
     wearables_TAG: v1.4.0 
     icub_main_TAG: v1.21.0    


### PR DESCRIPTION
This should fix failures in the CI such as https://github.com/robotology/human-dynamics-estimation/runs/7298646496?check_suite_focus=true