### PR TITLE
Change IK time logging to TRACE level

### DIFF
--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -1367,7 +1367,7 @@ void HumanStateProvider::run()
     }
 
     auto tock = std::chrono::high_resolution_clock::now();
-    yDebug() << LogPrefix << "IK took"
+    yTrace() << LogPrefix << "IK took"
              << std::chrono::duration_cast<std::chrono::milliseconds>(tock - tick).count() << "ms";
 
     // If useDirectBaseMeasurement is true, directly use the measured base pose and velocity. If useFixedBase is also enabled,


### PR DESCRIPTION
The message `IK took <x> ms` is logged at each iteration of the HumanStateProvider's main loop.

This pollutes the log and I suppose it was put for code debugging purpose.

This PR is to log that message with `TRACE` level. According to https://www.yarp.it/git-master/yarp_logging.html, this should generate no binary code (so no message) when the code is compiled in `Release` configuration.

cc @GiulioRomualdi 