### PR TITLE
Make dependency on robometry optional and add it in the documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
             cmake -A x64 cmake -G"Visual Studio 17 2022" -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                                                          -DCMAKE_BUILD_TPYE=${{matrix.build_type}} \
                                                          -DHUMANSTATEPROVIDER_ENABLE_VISUALIZER:BOOL=ON \
+                                                         -DHUMANSTATEPROVIDER_ENABLE_LOGGER:BOOL=ON \
                                                          -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
             
         - name: Configure [Ubuntu/macOS]
@@ -222,6 +223,7 @@ jobs:
             cd build
             cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                   -DHUMANSTATEPROVIDER_ENABLE_VISUALIZER:BOOL=ON \
+                  -DHUMANSTATEPROVIDER_ENABLE_LOGGER:BOOL=ON \
                   -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
         
         # Build step          

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Remove deprecated models. (https://github.com/robotology/human-dynamics-estimation/pull/322)
 
+### Changed
+- Dependency on robometry is changed to optional. (https://github.com/robotology/human-dynamics-estimation/pull/323)
+
 ## [2.7.0] - 2020-10-20
 
 First release with CHANGELOG.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ include(CTest)
 
 option(HUMANSTATEPROVIDER_ENABLE_VISUALIZER "Enable the iDyntree-irricht based Human State Visualizer" OFF)
 
+find_package(robometry QUIET)
+option(HUMANSTATEPROVIDER_ENABLE_LOGGER "Enable the robometry based Human Logger" ${robometry_FOUND})
+
 option(BUILD_TESTING "Build tests" OFF)
 
 # Find packages needed for this main CMakeLists.txt.

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ For installing the dependencies you can decide to install them individually or t
 - [**Wearables**](https://github.com/robotology/wearables): a library for communication and interfaces with wearable sensors.
 - [**Eigen**](http://eigen.tuxfamily.org/index.php?title=Main_Page) (3.3 or later): a C++ template library for linear algebra.
 - [**IPOPT**](http://wiki.icub.org/wiki/Installing_IPOPT): a software package for large-scale nonlinear optimization.
-- [**Robometry**](https://github.com/robotology/robometry) : a telemetry suite for logging data.
 
 #### Optional dependencies
 - [**ROS**](http://wiki.ros.org) with [**rviz**](http://wiki.ros.org/rviz) package: an open-source provider of libraries and tools for creating robot applications.
 - [**irrlicht**](http://irrlicht.sourceforge.net/) and [**iDynTree**](https://github.com/robotology/idyntree) compiled with `IDYNTREE_USES_IRRLICHT` enabled: visualizer for floating-base rigid-body systems.
+- [**Robometry**](https://github.com/robotology/robometry) : a telemetry suite for logging data.
 
 ## How to install
 After installing all the dependencies, you can install the HDE project:
@@ -59,7 +59,8 @@ cmake -DCMAKE_INSTALL_PREFIX=/path/to/your/installation/folder -G "name-of-your-
 ```
 where the `name-of-your-cmake-generator` is your project generator, see [Cmake-Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html). For example, on macOS you may choose `Xcode`, or on Unix `Unix Makefiles`.
 You can configure the following optional cmake options:
-- `HUMANSTATEPROVIDER_ENABLE_VISUALIZER`: enables the `irricht`-based iDynTree Visualizer
+- `HUMANSTATEPROVIDER_ENABLE_VISUALIZER`: enables the `irricht`-based iDynTree Visualizer.
+- `HUMANSTATEPROVIDER_ENABLE_LOGGER`: enables the `robometry`-based data logger.
 
 Then, for compiling
 ```bash

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For installing the dependencies you can decide to install them individually or t
 - [**Wearables**](https://github.com/robotology/wearables): a library for communication and interfaces with wearable sensors.
 - [**Eigen**](http://eigen.tuxfamily.org/index.php?title=Main_Page) (3.3 or later): a C++ template library for linear algebra.
 - [**IPOPT**](http://wiki.icub.org/wiki/Installing_IPOPT): a software package for large-scale nonlinear optimization.
+- [**Robometry**](https://github.com/robotology/robometry : a telemetry suite for logging data.
 
 #### Optional dependencies
 - [**ROS**](http://wiki.ros.org) with [**rviz**](http://wiki.ros.org/rviz) package: an open-source provider of libraries and tools for creating robot applications.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For installing the dependencies you can decide to install them individually or t
 - [**Wearables**](https://github.com/robotology/wearables): a library for communication and interfaces with wearable sensors.
 - [**Eigen**](http://eigen.tuxfamily.org/index.php?title=Main_Page) (3.3 or later): a C++ template library for linear algebra.
 - [**IPOPT**](http://wiki.icub.org/wiki/Installing_IPOPT): a software package for large-scale nonlinear optimization.
-- [**Robometry**](https://github.com/robotology/robometry : a telemetry suite for logging data.
+- [**Robometry**](https://github.com/robotology/robometry) : a telemetry suite for logging data.
 
 #### Optional dependencies
 - [**ROS**](http://wiki.ros.org) with [**rviz**](http://wiki.ros.org/rviz) package: an open-source provider of libraries and tools for creating robot applications.

--- a/devices/CMakeLists.txt
+++ b/devices/CMakeLists.txt
@@ -7,4 +7,7 @@ add_subdirectory(HumanWrenchProvider)
 add_subdirectory(HumanDynamicsEstimator)
 add_subdirectory(HumanControlBoard)
 add_subdirectory(RobotPositionController)
-add_subdirectory(HumanLogger)
+
+if(HUMANSTATEPROVIDER_ENABLE_LOGGER)
+    add_subdirectory(HumanLogger)
+endif()


### PR DESCRIPTION
In https://github.com/robotology/human-dynamics-estimation/pull/298 we forgot to update the documentation with the `robometry` dependency.