### PR TITLE
Remove deprecated YARP headers

### DIFF
--- a/devices/HumanControlBoard/HumanControlBoard.h
+++ b/devices/HumanControlBoard/HumanControlBoard.h
@@ -15,7 +15,8 @@
 #include <yarp/dev/IPositionControl.h>
 #include <yarp/dev/ITorqueControl.h>
 #include <yarp/dev/IVelocityControl.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/IControlLimits.h>
 

--- a/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.h
+++ b/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.h
@@ -10,7 +10,8 @@
 #define HDE_DEVICES_HUMANDYNAMICSESTIMATOR
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 #include <hde/interfaces/IHumanDynamics.h>

--- a/devices/HumanLogger/HumanLogger.h
+++ b/devices/HumanLogger/HumanLogger.h
@@ -11,7 +11,8 @@
 
 #include <memory>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 namespace hde {

--- a/devices/HumanStateProvider/HumanStateProvider.h
+++ b/devices/HumanStateProvider/HumanStateProvider.h
@@ -10,9 +10,9 @@
 #define HDE_DEVICES_HUMANSTATEPROVIDER
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/os/PeriodicThread.h>
-
+#include <yarp/dev/IWrapper.h>
 #include <hde/interfaces/IHumanState.h>
 #include <hde/interfaces/IWearableTargets.h>
 

--- a/devices/HumanWrenchProvider/HumanWrenchProvider.h
+++ b/devices/HumanWrenchProvider/HumanWrenchProvider.h
@@ -11,7 +11,8 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 #include <hde/interfaces/IHumanWrench.h>

--- a/devices/RobotPositionController/RobotPositionController.h
+++ b/devices/RobotPositionController/RobotPositionController.h
@@ -11,7 +11,8 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IWrapper.h>
 
 #include <memory>
 

--- a/publishers/HumanDynamicsPublisher/HumanDynamicsPublisher.h
+++ b/publishers/HumanDynamicsPublisher/HumanDynamicsPublisher.h
@@ -10,7 +10,8 @@
 #define HDE_DEVICES_HUMANDYNAMICSPUBLISHER
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 #include <memory>

--- a/publishers/HumanStatePublisher/HumanStatePublisher.h
+++ b/publishers/HumanStatePublisher/HumanStatePublisher.h
@@ -10,7 +10,8 @@
 #define HDE_DEVICES_HUMANSTATEPUBLISHER
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 #include <memory>

--- a/publishers/XsensTFPublisher/XsensTFPublisher.h
+++ b/publishers/XsensTFPublisher/XsensTFPublisher.h
@@ -10,7 +10,8 @@
 #define HDE_DEVICES_XSENSTFPUBLISHER
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 #include <memory>

--- a/remappers/HumanDynamicsRemapper/HumanDynamicsRemapper.h
+++ b/remappers/HumanDynamicsRemapper/HumanDynamicsRemapper.h
@@ -12,7 +12,7 @@
 #include <hde/interfaces/IHumanDynamics.h> 
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/TypedReaderCallback.h>
 

--- a/remappers/HumanStateRemapper/HumanStateRemapper.h
+++ b/remappers/HumanStateRemapper/HumanStateRemapper.h
@@ -12,7 +12,7 @@
 #include <hde/interfaces/IHumanState.h>
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/TypedReaderCallback.h>
 

--- a/remappers/WearableTargetsRemapper/WearableTargetsRemapper.h
+++ b/remappers/WearableTargetsRemapper/WearableTargetsRemapper.h
@@ -12,7 +12,7 @@
 #include <hde/interfaces/IWearableTargets.h>
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/TypedReaderCallback.h>
 

--- a/wrappers/HumanDynamicsWrapper/HumanDynamicsWrapper.h
+++ b/wrappers/HumanDynamicsWrapper/HumanDynamicsWrapper.h
@@ -10,7 +10,8 @@
 #define HDE_DEVICES_HUMANDYNAMICSWRAPPER
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 #include <memory>

--- a/wrappers/HumanStateWrapper/HumanStateWrapper.h
+++ b/wrappers/HumanStateWrapper/HumanStateWrapper.h
@@ -10,7 +10,8 @@
 #define HDE_DEVICES_HUMANSTATEWRAPPER
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 #include <memory>

--- a/wrappers/WearableTargetsWrapper/WearableTargetsWrapper.h
+++ b/wrappers/WearableTargetsWrapper/WearableTargetsWrapper.h
@@ -10,7 +10,8 @@
 #define HDE_DEVICES_WEARABLETARGETSWRAPPER
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 #include <memory>


### PR DESCRIPTION
Removing deprecated YARP headers (see https://github.com/robotology/human-dynamics-estimation/issues/324)