### PR TITLE
Fix typo in DynamicalInverseKinematics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Dependency on robometry is changed to optional. (https://github.com/robotology/human-dynamics-estimation/pull/323)
 
+### Fixed
+- Fixed a typo in `DynamicalInverseKinematics` that caused a wrong calculation of the rotation mean error. (https://github.com/robotology/human-dynamics-estimation/pull/330)
+
 ## [2.7.0] - 2020-10-20
 
 First release with CHANGELOG.

--- a/HumanDynamicsEstimationLibrary/algorithms/src/DynamicalInverseKinematics.cpp
+++ b/HumanDynamicsEstimationLibrary/algorithms/src/DynamicalInverseKinematics.cpp
@@ -1023,7 +1023,7 @@ bool DynamicalInverseKinematics::impl::computeDesiredLinkVelocities()
 
                     if (rotActivation[idx])
                     {
-                        nrPosTargets[idx] +=1;
+                        nrRotTargets[idx] +=1;
                     }
                 }
                 iDynTree::toEigen(m_desiredLinearVelocityBuffer) = target.getLinearVelocityFeedforwardGain() * iDynTree::toEigen(target.getLinearVelocity())


### PR DESCRIPTION
This PR fixes a typo in `DynamicalInverseKinematics` that caused a wrong calculation of the `m_netMeanRotErr`.