### PR TITLE
Fix HumanLogger not working when logging just one quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed a typo in `DynamicalInverseKinematics` that caused a wrong calculation of the rotation mean error. (https://github.com/robotology/human-dynamics-estimation/pull/330)
+- Fixed `HumanLogger` when logging just one kind of data (https://github.com/robotology/human-dynamics-estimation/pull/338)
 
 ## [2.7.0] - 2020-10-20
 

--- a/devices/HumanLogger/HumanLogger.cpp
+++ b/devices/HumanLogger/HumanLogger.cpp
@@ -318,7 +318,7 @@ bool HumanLogger::attach(yarp::dev::PolyDriver* poly)
     std::cerr << "attaching " << deviceName << std::endl;
     if (deviceName == "human_state_provider" || deviceName == "human_state_remapper") {
         // Attach IHumanState interface
-        if (pImpl->iHumanState || !poly->view(pImpl->iHumanState) || !pImpl->iHumanState) {
+        if (!poly->view(pImpl->iHumanState) || !pImpl->iHumanState) {
             yError() << logPrefix << "Failed to view IHumanState interface from the polydriver";
             return false;
         }
@@ -335,7 +335,7 @@ bool HumanLogger::attach(yarp::dev::PolyDriver* poly)
 
     if (deviceName == "human_dynamics_estimator" || deviceName == "human_dynamics_remapper") {
         // Attach IHumanDynamics interface
-        if (pImpl->iHumanDynamics || !poly->view(pImpl->iHumanDynamics) || !pImpl->iHumanDynamics) {
+        if (!poly->view(pImpl->iHumanDynamics) || !pImpl->iHumanDynamics) {
             yError() << logPrefix << "Failed to view IHumanDynamics interface from the polydriver";
             return false;
         }


### PR DESCRIPTION
The periodic thread (e.g. the `run()` function) in human logger is started inside the `attachAll` method.

Turns out that, since the device implements both `IWrapper` and `IMultipleWrapper`, the first one is preferred when the list of devices to attach contains only one of them (see [here](https://github.com/robotology/yarp/blob/e845b1de554f4bf67c262de9794ebbc2bf9ca29f/src/libYARP_robotinterface/src/yarp/robotinterface/Device.cpp#L416-L451)).

In such case, only the `attach()` method belonging to `IWrapper` is called. 
In our case, this happens when using the logging of only one between the kinematics and dynamics data.

This PR is to solve this issue.