### PR TITLE
Added custom settings for calibration and visualization options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] - 2023-02-16
+
 ### Removed
 - Remove deprecated models. (https://github.com/robotology/human-dynamics-estimation/pull/322)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added custom options for window dimensions (https://github.com/robotology/human-dynamics-estimation/pull/341).
+- Added a parameter that allows to set custom angles for calibration purposes (https://github.com/robotology/human-dynamics-estimation/pull/341).
+
 ## [2.7.1] - 2023-02-16
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added custom options for window dimensions (https://github.com/robotology/human-dynamics-estimation/pull/341).
-- Added a parameter that allows to set custom angles for calibration purposes (https://github.com/robotology/human-dynamics-estimation/pull/341).
+- [`HumanStateVisualizer`] Added custom options for window dimensions (https://github.com/robotology/human-dynamics-estimation/pull/341).
+- [`HumanStateProvider`] Added a parameter that allows to set custom angles for calibration purposes (https://github.com/robotology/human-dynamics-estimation/pull/341).
 
 ## [2.7.1] - 2023-02-16
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(HumanDynamicsEstimation
         LANGUAGES CXX
-        VERSION 2.7.0)
+        VERSION 2.7.1)
 
 # =====================
 # PROJECT CONFIGURATION

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -439,7 +439,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
     std::vector<double> calibrationJointConfiguration;
     if (!config.check("calibrationJointConfiguration"))
     {
-        yInfo() << LogPrefix << "calibrationJointConfiguration option not found or not valid, using zero configuration instead.";
+        yInfo() << LogPrefix << "calibrationJointConfiguration option not found, using zero configuration instead.";
         calibrationJointConfiguration.clear();
     }
     else

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -1065,10 +1065,18 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
     pImpl->jointCalibrationSolution.resize(nrOfDOFs);
 
     // Fill iDynTreeVector with 0 if calibration configuration list is empty
-    if (calibrationJointConfiguration.empty()){
+    if (calibrationJointConfiguration.empty())
+    {
         pImpl->jointCalibrationSolution.zero();
     }
-    else {
+    else if(calibrationJointConfiguration.size() != nrOfDOFs)
+    {
+        yError() << LogPrefix << "calibrationJointConfiguration param size (" << calibrationJointConfiguration.size() 
+                 << ") must match the number of DOFs of the model (" << nrOfDOFs <<"). ";
+        return false;
+    }
+    else
+    {
         for (int idx = 0; idx < calibrationJointConfiguration.size(); idx++) {
             pImpl->jointCalibrationSolution.setVal(idx, calibrationJointConfiguration[idx]);
         }

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -443,6 +443,11 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
     else
     {
         auto calibrationJointConfigurationBottle = config.find("calibrationJointConfiguration").asList();
+        if(calibrationJointConfigurationBottle->size()!=jointList.size())
+        {
+                yError() << LogPrefix << "Parameter calibrationJointConfiguration must have the same size of the list of selected joints!";
+                return false;
+        }
         for (size_t it = 0; it < calibrationJointConfigurationBottle->size(); it++)
         {
             pImpl->calibrationJointConfiguration.push_back(calibrationJointConfigurationBottle->get(it).asFloat64());

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -437,13 +437,20 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
     }
 
     std::vector<double> calibrationJointConfiguration;
-    if (!(config.check("calibrationJointConfiguration") && config.find("calibrationJointConfiguration").isList())) {
+    if (!config.check("calibrationJointConfiguration"))
+    {
         yInfo() << LogPrefix << "calibrationJointConfiguration option not found or not valid, using zero configuration instead.";
-       calibrationJointConfiguration.clear();
+        calibrationJointConfiguration.clear();
     }
     else
     {
-        auto calibrationJointConfigurationBottle = config.find("calibrationJointConfiguration").asList();
+        auto calibrationJointConfigurationValue = config.find("calibrationJointConfiguration");
+        if(!calibrationJointConfigurationValue.isList())
+        {
+            yError() << LogPrefix << "Param calibrationJointConfiguration must be a list";
+            return false;
+        }
+        auto calibrationJointConfigurationBottle = calibrationJointConfigurationValue.asList();
         if(calibrationJointConfigurationBottle->size() !=  pImpl->jointList.size())
         {
                 yError() << LogPrefix << "Parameter calibrationJointConfiguration must have the same size of the list of selected joints!";

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -443,7 +443,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
     else
     {
         auto calibrationJointConfigurationBottle = config.find("calibrationJointConfiguration").asList();
-        if(calibrationJointConfigurationBottle->size() !=  config.find("jointList").asList()->size())
+        if(calibrationJointConfigurationBottle->size() !=  pImpl->jointList.size())
         {
                 yError() << LogPrefix << "Parameter calibrationJointConfiguration must have the same size of the list of selected joints!";
                 return false;

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -162,7 +162,7 @@ public:
     FloatingBaseName floatingBaseFrame;
 
     std::vector<std::string> jointList;
-    std::vector<double> CalibrationConfig;
+    std::vector<double> calibrationJointConfiguration;
 
     std::vector<SegmentInfo> segments;
     std::vector<LinkPairInfo> linkPairs;
@@ -436,16 +436,16 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
         }
     }
 
-     if (!(config.check("CalibrationConfig") && config.find("CalibrationConfig").isList())) {
-        yInfo() << LogPrefix << "CalibrationConfig option not found or not valid, all the model joints are selected.";
-        pImpl->CalibrationConfig.clear();
+     if (!(config.check("calibrationJointConfiguration") && config.find("calibrationJointConfiguration").isList())) {
+        yInfo() << LogPrefix << "calibrationJointConfiguration option not found or not valid, using zero configuration instead.";
+        pImpl->calibrationJointConfiguration.clear();
     }
     else
     {
-        auto CalibrationConfigBottle = config.find("CalibrationConfig").asList();
-        for (size_t it = 0; it < CalibrationConfigBottle->size(); it++)
+        auto calibrationJointConfigurationBottle = config.find("calibrationJointConfiguration").asList();
+        for (size_t it = 0; it < calibrationJointConfigurationBottle->size(); it++)
         {
-            pImpl->CalibrationConfig.push_back(CalibrationConfigBottle->get(it).asFloat64());
+            pImpl->calibrationJointConfiguration.push_back(calibrationJointConfigurationBottle->get(it).asFloat64());
         }
     }
 
@@ -1531,9 +1531,8 @@ void HumanStateProvider::impl::computeSecondaryCalibrationRotationsForChain(cons
     iDynTree::Twist baseVel;
     baseVel.zero();
 
-    // setting to zero all the selected joints
     for (auto const& jointZeroIdx: jointZeroIndices) {
-        jointPos.setVal(jointZeroIdx, CalibrationConfig[jointZeroIdx]);
+        jointPos.setVal(jointZeroIdx, calibrationJointConfiguration[jointZeroIdx]);
     }
     // TODO check which value to give to the base (before we were using the base target measurement)
     kinDynComputations->setRobotState(iDynTree::Transform::Identity(), jointPos, baseVel, jointVel, worldGravity);
@@ -1635,7 +1634,7 @@ bool HumanStateProvider::impl::applyRpcCommand()
         // setting to zero all the selected joints
         for (auto const& jointZeroIdx: jointZeroIndices) {
 
-            jointPos.setVal(jointZeroIdx, CalibrationConfig[jointZeroIdx]);
+            jointPos.setVal(jointZeroIdx, calibrationJointConfiguration[jointZeroIdx]);
             
         }
 

--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -443,7 +443,7 @@ bool HumanStateProvider::open(yarp::os::Searchable& config)
     else
     {
         auto calibrationJointConfigurationBottle = config.find("calibrationJointConfiguration").asList();
-        if(calibrationJointConfigurationBottle->size()!=jointList.size())
+        if(calibrationJointConfigurationBottle->size() !=  config.find("jointList").asList()->size())
         {
                 yError() << LogPrefix << "Parameter calibrationJointConfiguration must have the same size of the list of selected joints!";
                 return false;

--- a/modules/HumanStateVisualizer/src/main.cpp
+++ b/modules/HumanStateVisualizer/src/main.cpp
@@ -542,6 +542,9 @@ int main(int argc, char* argv[])
     iDynTree::Visualizer viz;
     iDynTree::VisualizerOptions options;
 
+    options.winHeight = rf.check("windowHeight", yarp::os::Value(options.winHeight)).asInt32();
+    options.winWidth = rf.check("windowWidth", yarp::os::Value(options.winWidth)).asInt32();
+
     viz.init(options);
 
     viz.camera().setPosition(cameraDeltaPosition);


### PR DESCRIPTION
As per the title, with @S-Dafarra we included the possibility to define window's Height and Width from the configuration file of the Human State Visualizer. Also, with @lrapetti and @mebbaid we define a new parameter called CalibrationConfig that allows setting custom angles for calibration purposes.