### PR TITLE
Fix calibration using jointCalibrationSolution

### DIFF
--- a/devices/HumanStateProvider/HumanStateProvider.cpp
+++ b/devices/HumanStateProvider/HumanStateProvider.cpp
@@ -1565,7 +1565,7 @@ void HumanStateProvider::impl::computeSecondaryCalibrationRotationsForChain(cons
     baseVel.zero();
 
     for (auto const& jointZeroIdx: jointZeroIndices) {
-        jointPos.setVal(jointZeroIdx, jointConfigurationSolution.getVal(jointZeroIdx));
+        jointPos.setVal(jointZeroIdx, jointCalibrationSolution.getVal(jointZeroIdx));
     }
     // TODO check which value to give to the base (before we were using the base target measurement)
     kinDynComputations->setRobotState(iDynTree::Transform::Identity(), jointPos, baseVel, jointVel, worldGravity);
@@ -1665,7 +1665,7 @@ bool HumanStateProvider::impl::applyRpcCommand()
 
         for (auto const& jointZeroIdx: jointZeroIndices) {
 
-            jointPos.setVal(jointZeroIdx, jointConfigurationSolution.getVal(jointZeroIdx));
+            jointPos.setVal(jointZeroIdx, jointCalibrationSolution.getVal(jointZeroIdx));
             
         }
 


### PR DESCRIPTION
In https://github.com/robotology/human-dynamics-estimation/pull/341, after the code review we have introduced a bug and the calibration was no longer performed correctly.

The problem was that the `jointCalibrationSolution` was never used, while the current configuration (`jointConfigurationSolution`) was used to calibrate the joints. This PR fix the bug