### PR TITLE
Add joint names to logger (Fix #351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [`HumanLogger`] Removed IWrapper from implemented interface to fix checks on log flags and attached interfaces (https://github.com/robotology/human-dynamics-estimation/pull/344)
+- [`HumanLogger`] Fix joint names (https://github.com/robotology/human-dynamics-estimation/pull/352)
 
 
 ## [2.7.1] - 2023-02-16

--- a/devices/HumanLogger/HumanLogger.cpp
+++ b/devices/HumanLogger/HumanLogger.cpp
@@ -64,11 +64,11 @@ public:
 
     // buffer variables
     // iHumanState
-    std::array<double, 3> basePositionInterface;
-    std::array<double, 4> baseOrientationInterface;
-    std::array<double, 6> baseVelocityInterface;
-    std::vector<double> jointPositionsInterface;
-    std::vector<double> jointVelocitiesInterface;
+    std::array<double, 3> basePosition;
+    std::array<double, 4> baseOrientation;
+    std::array<double, 6> baseVelocity;
+    std::vector<double> jointPositions;
+    std::vector<double> jointVelocities;
     std::vector<std::string> jointNamesStateInterface;
     // iHumanDynamics
     std::vector<double> jointTorquesInterface;
@@ -103,26 +103,26 @@ void HumanLogger::run()
             return;
         }
 
-        pImpl->basePositionInterface = pImpl->iHumanState->getBasePosition();
-        pImpl->baseOrientationInterface = pImpl->iHumanState->getBaseOrientation();
-        pImpl->baseVelocityInterface = pImpl->iHumanState->getBaseVelocity();
-        pImpl->jointPositionsInterface = pImpl->iHumanState->getJointPositions();
-        pImpl->jointVelocitiesInterface = pImpl->iHumanState->getJointVelocities();
+        pImpl->basePosition = pImpl->iHumanState->getBasePosition();
+        pImpl->baseOrientation = pImpl->iHumanState->getBaseOrientation();
+        pImpl->baseVelocity = pImpl->iHumanState->getBaseVelocity();
+        pImpl->jointPositions = pImpl->iHumanState->getJointPositions();
+        pImpl->jointVelocities = pImpl->iHumanState->getJointVelocities();
 
         if (pImpl->loggerType == LoggerType::MATLAB) {
-            pImpl->bufferManager.push_back(pImpl->basePositionInterface,
+            pImpl->bufferManager.push_back(pImpl->basePosition,
                                            timeNow,
                                            "human_state::base_position");
-            pImpl->bufferManager.push_back(pImpl->baseOrientationInterface,
+            pImpl->bufferManager.push_back(pImpl->baseOrientation,
                                            timeNow,
                                            "human_state::base_orientation");
-            pImpl->bufferManager.push_back(pImpl->baseVelocityInterface,
+            pImpl->bufferManager.push_back(pImpl->baseVelocity,
                                            timeNow,
                                            "human_state::base_velocity");
-            pImpl->bufferManager.push_back(pImpl->jointPositionsInterface,
+            pImpl->bufferManager.push_back(pImpl->jointPositions,
                                            timeNow,
                                            "human_state::joint_positions");
-            pImpl->bufferManager.push_back(pImpl->jointVelocitiesInterface,
+            pImpl->bufferManager.push_back(pImpl->jointVelocities,
                                            timeNow,
                                            "human_state::joint_velocities");
         }

--- a/devices/HumanLogger/HumanLogger.cpp
+++ b/devices/HumanLogger/HumanLogger.cpp
@@ -69,10 +69,10 @@ public:
     std::array<double, 6> baseVelocity;
     std::vector<double> jointPositions;
     std::vector<double> jointVelocities;
-    std::vector<std::string> jointNamesStateInterface;
+    std::vector<std::string> jointNamesState;
     // iHumanDynamics
     std::vector<double> jointTorquesInterface;
-    std::vector<std::string> jointNamesDynamicsInterface;
+    std::vector<std::string> jointNamesDynamics;
 
 };
 
@@ -303,20 +303,20 @@ bool HumanLogger::impl::configureBufferManager()
     if(settings.logHumanState) {
         if (loggerType == LoggerType::MATLAB)
         {
-            jointNamesStateInterface =  iHumanState->getJointNames();
+            jointNamesState =  iHumanState->getJointNames();
             ok = ok && bufferManager.addChannel({"human_state::base_position", {3, 1}});
             ok = ok && bufferManager.addChannel({"human_state::base_orientation", {4, 1}});
             ok = ok && bufferManager.addChannel({"human_state::base_velocity", {6, 1}});
-            ok = ok && bufferManager.addChannel({"human_state::joint_positions", {jointNamesStateInterface.size(), 1}});
-            ok = ok && bufferManager.addChannel({"human_state::joint_velocities", {jointNamesStateInterface.size(), 1}});
+            ok = ok && bufferManager.addChannel({"human_state::joint_positions", {jointNamesState.size(), 1}, jointNamesState});
+            ok = ok && bufferManager.addChannel({"human_state::joint_velocities", {jointNamesState.size(), 1}, jointNamesState});
         }
     }
     if (settings.logHumanDynamics)
     {
         if (loggerType == LoggerType::MATLAB)
         {
-            jointNamesDynamicsInterface =  iHumanDynamics->getJointNames();
-            ok = ok && bufferManager.addChannel({"human_dynamics::joint_torques", {jointNamesDynamicsInterface.size(), 1}});
+            jointNamesDynamics =  iHumanDynamics->getJointNames();
+            ok = ok && bufferManager.addChannel({"human_dynamics::joint_torques", {jointNamesDynamics.size(), 1}, jointNamesDynamics});
         }
     }
     


### PR DESCRIPTION
Fix for #351.

As you can see the joint names are now available in the following dataset:
![Screenshot 2023-08-31 at 15 35 06](https://github.com/robotology/human-dynamics-estimation/assets/35487806/8d6ab8d7-5359-4c5e-a00b-4f41536da81d)
[human_data_1693488825.495321.mat.zip](https://github.com/robotology/human-dynamics-estimation/files/12486675/human_data_1693488825.495321.mat.zip)
