### PR TITLE
Remove outputPortName from iwear_remapper configuration files (#215)

### DIFF
--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -14,7 +14,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="HumanStateProvider">
@@ -121,7 +120,6 @@
         <param name="wearableDataPorts">(/FTShoeLeft/WearableData/data:o /FTShoeRight/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/FTShoeLeft/WearableData/metadataRpc:o /FTShoeRight/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/FTSourcesIWearRemapper/data:o</param>
     </device>
 
     <device type="human_wrench_provider" name="HumanWrenchProvider">
@@ -311,7 +309,6 @@
         <param name="wearableDataPorts">(/FTShoeLeft/WearableData/data:o /FTShoeRight/WearableData/data:o /XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/FTShoeLeft/WearableData/metadataRpc:o /FTShoeRight/WearableData/metadataRpc:o /XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/IWearRemapper/data:o</param>
     </device>
 
     <device type="iwear_wrapper" name="WearableDataWrapper">

--- a/conf/xml/HumanStateProvider.xml
+++ b/conf/xml/HumanStateProvider.xml
@@ -6,7 +6,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="HumanStateProvider">

--- a/conf/xml/HumanStateProvider_second.xml
+++ b/conf/xml/HumanStateProvider_second.xml
@@ -6,7 +6,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData_2/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData_2/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE_2/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="HumanStateProvider_2">

--- a/conf/xml/RobotStateProvider_Atlas.xml
+++ b/conf/xml/RobotStateProvider_Atlas.xml
@@ -6,7 +6,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/Atlas/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">

--- a/conf/xml/RobotStateProvider_Baxter.xml
+++ b/conf/xml/RobotStateProvider_Baxter.xml
@@ -6,7 +6,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/Baxter/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">

--- a/conf/xml/RobotStateProvider_Human.xml
+++ b/conf/xml/RobotStateProvider_Human.xml
@@ -6,7 +6,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/Human/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="HumanStateProvider">

--- a/conf/xml/RobotStateProvider_Nao.xml
+++ b/conf/xml/RobotStateProvider_Nao.xml
@@ -6,7 +6,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/Nao/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">

--- a/conf/xml/RobotStateProvider_Walkman.xml
+++ b/conf/xml/RobotStateProvider_Walkman.xml
@@ -6,7 +6,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/Walkman/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">

--- a/conf/xml/RobotStateProvider_iCub2_5.xml
+++ b/conf/xml/RobotStateProvider_iCub2_5.xml
@@ -6,7 +6,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/iCub/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">

--- a/conf/xml/RobotStateProvider_iCub2_5_Pole.xml
+++ b/conf/xml/RobotStateProvider_iCub2_5_Pole.xml
@@ -6,7 +6,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/iCub/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">

--- a/conf/xml/RobotStateProvider_iCub3.xml
+++ b/conf/xml/RobotStateProvider_iCub3.xml
@@ -6,7 +6,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/iCub/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">

--- a/conf/xml/RobotStateProvider_iCub3_Pole.xml
+++ b/conf/xml/RobotStateProvider_iCub3_Pole.xml
@@ -6,7 +6,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/iCub/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">

--- a/conf/xml/WholeBodyRetargeting.xml
+++ b/conf/xml/WholeBodyRetargeting.xml
@@ -14,7 +14,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="RobotStateProvider">

--- a/conf/xml/hands-pHRI.xml
+++ b/conf/xml/hands-pHRI.xml
@@ -14,7 +14,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="HumanStateProvider">
@@ -114,7 +113,6 @@
         <param name="wearableDataPorts">(/ICub/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/ICub/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/FTSourcesIWearRemapper/data:o</param>
     </device>
 
     <device type="human_wrench_provider" name="HumanWrenchProvider">

--- a/conf/xml/pHRI.xml
+++ b/conf/xml/pHRI.xml
@@ -15,7 +15,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/XsensIWearRemapper/data:o</param>
     </device>
 
     <device type="human_state_provider" name="HumanStateProvider">
@@ -115,7 +114,6 @@
         <param name="wearableDataPorts">(/FTShoeLeft/WearableData/data:o /FTShoeRight/WearableData/data:o /ICub/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/FTShoeLeft/WearableData/metadataRpc:o /FTShoeRight/WearableData/metadataRpc:o /ICub/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/HDE/FTSourcesIWearRemapper/data:o</param>
     </device>
 
     <device type="human_wrench_provider" name="HumanWrenchProvider">
@@ -311,7 +309,6 @@
         <param name="wearableDataPorts">(/XSensSuit/WearableData/data:o /FTShoeLeft/WearableData/data:o /FTShoeRight/WearableData/data:o /ICub/WearableData/data:o)</param>
         <param name="useRPC">false</param>
         <param name="wearableRPCPorts">(/XSensSuit/WearableData/metadataRpc:o /FTShoeLeft/WearableData/metadataRpc:o /FTShoeRight/WearableData/metadataRpc:o /ICub/WearableData/metadataRpc:o)</param>
-        <param name="outputPortName">/pHRI/IWearRemapper/data:o</param>
     </device>
 
     <device type="iwear_wrapper" name="pHRIWearableDataWrapper">


### PR DESCRIPTION
As mentioned in https://github.com/robotology/human-dynamics-estimation/issues/215, this parameter was removed in https://github.com/robotology/wearables/pull/34