### PR TITLE
Bump human-dynamics-estimation version to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Naming convention from `wrapper`\ `server` to `nws`\ `nwc` (https://github.com/robotology/human-dynamics-estimation/pull/367).
-- HumanLogger device to be compatible with the `robot-log-visualizer` (https://github.com/robotology/human-dynamics-estimation/pull/372).
+
+| Old name | New name |
+|:------------:|:--------------:|
+| HumanDynamicsWrapper | HumanDynamics_nws_yarp |
+| HumanDynamicsRemapper | HumanDynamics_nwc_yarp |
+| HumanStateWrapper | HumanState_nws_yarp |
+| HumanStateRemapper | HumanState_nwc_yarp |
+| HumanWrenchWrapper | HumanWrench_nws_yarp |
+| HumanWrenchRemapper | HumanWrench_nwc_yarp |
+| WearableTargetsWrapper | WearableTargets_nws_yarp |
+| WearableTargetsRemapper | WearableTargets_nwc_yarp |
+
+-  HumanLogger device to be compatible with the `robot-log-visualizer` (https://github.com/robotology/human-dynamics-estimation/pull/372).
 
 ### Added
 - Added files for ergoCub teleoperation without using iFeel (https://github.com/robotology/human-dynamics-estimation/pull/374)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Naming convention from `wrapper`\ `server` to `nws`\ `nwc` (https://github.com/robotology/human-dynamics-estimation/pull/367).
 
-| Old name | New name |
+| Previous devices name | New devices name |
 |:------------:|:--------------:|
 | HumanDynamicsWrapper | HumanDynamics_nws_yarp |
 | HumanDynamicsRemapper | HumanDynamics_nwc_yarp |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2023-11-09
+
 ### Changed
 - Naming convention from `wrapper`\ `server` to `nws`\ `nwc` (https://github.com/robotology/human-dynamics-estimation/pull/367).
 - HumanLogger device to be compatible with the `robot-log-visualizer` (https://github.com/robotology/human-dynamics-estimation/pull/372).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(HumanDynamicsEstimation
         LANGUAGES CXX
-        VERSION 2.9.0)
+        VERSION 3.0.0)
 
 # =====================
 # PROJECT CONFIGURATION


### PR DESCRIPTION
Closes #373.
Before merging:
- [x] Update documentation with the mapping of the new device names @davidegorbani
- [x] Replace usage of `transformClient` in the configuration files (https://github.com/robotology/wearables/issues/191) @S-Dafarra 
- [x] Replace usage of `controlboardwrapper2` in the configuration files @lrapetti  https://github.com/robotology/human-dynamics-estimation/pull/378

### Changed
- Naming convention from `wrapper`\ `server` to `nws`\ `nwc` (https://github.com/robotology/human-dynamics-estimation/pull/367).
- HumanLogger device to be compatible with the `robot-log-visualizer` (https://github.com/robotology/human-dynamics-estimation/pull/372).

### Added
- Added files for ergoCub teleoperation without using iFeel (https://github.com/robotology/human-dynamics-estimation/pull/374)
