### PR TITLE
Replace controlboardwrapper2 with controlBoard_nws_yarp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Naming convention from `wrapper`\ `server` to `nws`\ `nwc` (https://github.com/robotology/human-dynamics-estimation/pull/367).
 - HumanLogger device to be compatible with the `robot-log-visualizer` (https://github.com/robotology/human-dynamics-estimation/pull/372).
+- `controlboardwrapper2` is replaced by `controlBoard_nws_yarp` (https://github.com/robotology/human-dynamics-estimation/pull/378).
 
 ### Added
 - Added files for ergoCub teleoperation without using iFeel (https://github.com/robotology/human-dynamics-estimation/pull/374)

--- a/conf/xml/Human.xml
+++ b/conf/xml/Human.xml
@@ -285,8 +285,8 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <device type="controlboardwrapper2" name="HumanControlBoardWrapper">
-        <param name="period">20</param>
+    <device type="controlBoard_nws_yarp" name="HumanControlBoardWrapper">
+        <param name="period">0.02</param>
         <param name="name">/Human/HumanControlBoard</param>
         <param name="joints">66</param>
         <paramlist name="networks">

--- a/conf/xml/hands-pHRI.xml
+++ b/conf/xml/hands-pHRI.xml
@@ -266,8 +266,8 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <device type="controlboardwrapper2" name="HumanControlBoardWrapper">
-        <param name="period">20</param>
+    <device type="controlBoard_nws_yarp" name="HumanControlBoardWrapper">
+        <param name="period">0.02</param>
         <param name="name">/Human/HumanControlBoard</param>
         <param name="joints">66</param>
         <paramlist name="networks">

--- a/conf/xml/pHRI.xml
+++ b/conf/xml/pHRI.xml
@@ -285,8 +285,8 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <device type="controlboardwrapper2" name="HumanControlBoardWrapper">
-        <param name="period">1</param>
+    <device type="controlBoard_nws_yarp" name="HumanControlBoardWrapper">
+        <param name="period">0.01</param>
         <param name="name">/Human/HumanControlBoard</param>
         <param name="joints">66</param>
         <paramlist name="networks">


### PR DESCRIPTION
The `controlboardwrapper2` is deprecated in `yarp` since https://github.com/robotology/yarp/releases/tag/v3.5.0