### PR TITLE
Fix compatibility with YARP 3.10

### DIFF
--- a/devices/HumanControlBoard/HumanControlBoard.cpp
+++ b/devices/HumanControlBoard/HumanControlBoard.cpp
@@ -57,7 +57,7 @@ public:
 
     yarp::sig::Vector jointTorques;
 
-    bool attach(yarp::dev::PolyDriver* poly);
+    bool attach(const std::string& deviceKey, yarp::dev::PolyDriver* poly);
 };
 
 // =========================
@@ -216,7 +216,7 @@ void HumanControlBoard::run()
 
 }
 
-bool HumanControlBoard::impl::attach(yarp::dev::PolyDriver* poly)
+bool HumanControlBoard::impl::attach(const std::string& deviceKey, yarp::dev::PolyDriver* poly)
 {
     if (!poly) {
         yError() << LogPrefix << "Passed PolyDriver is nullptr";
@@ -224,8 +224,7 @@ bool HumanControlBoard::impl::attach(yarp::dev::PolyDriver* poly)
     }
 
     // Get the device name from the driver
-    const std::string deviceName = poly->getValue("device").asString();
-    yInfo() << LogPrefix << "Attaching device"<<deviceName;
+    yInfo() << LogPrefix << "Attaching device"<<deviceKey;
 
     hde::interfaces::IHumanState* tmpIHumanState = nullptr;
     hde::interfaces::IHumanDynamics* tmpIHumanDynamics = nullptr;
@@ -242,7 +241,7 @@ bool HumanControlBoard::impl::attach(yarp::dev::PolyDriver* poly)
 
         isHumanStateAttached = true;
         iHumanState = tmpIHumanState;
-        yInfo() << LogPrefix << deviceName << "attached successful as IHumanState interface";
+        yInfo() << LogPrefix << deviceKey << "attached successful as IHumanState interface";
     }
 
     // Try to attach as IHumanDynamics
@@ -257,11 +256,11 @@ bool HumanControlBoard::impl::attach(yarp::dev::PolyDriver* poly)
 
         isHumanDynamicsAttached = true;
         iHumanDynamics = tmpIHumanDynamics;
-        yInfo() << LogPrefix << deviceName << "attached successfully as IHumanDynamics interface";
+        yInfo() << LogPrefix << deviceKey << "attached successfully as IHumanDynamics interface";
     }
 
     if(!tmpIHumanState && !tmpIHumanDynamics){
-        yError() << LogPrefix << "Unable to attach"<<deviceName<<"as one of the supported interfaces";
+        yError() << LogPrefix << "Unable to attach"<<deviceKey<<"as one of the supported interfaces";
         return false;
     }
 
@@ -287,7 +286,7 @@ bool HumanControlBoard::attachAll(const yarp::dev::PolyDriverList& driverList)
             return false;
         }
 
-        if(!pImpl->attach(driver->poly)) {
+        if(!pImpl->attach(driver->key, driver->poly)) {
             return false;
         }
     }

--- a/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.cpp
+++ b/devices/HumanDynamicsEstimator/HumanDynamicsEstimator.cpp
@@ -792,7 +792,7 @@ public:
     // Wrench sensor link names variable
     std::vector<std::string> wrenchSensorsLinkNames;
 
-    bool attach(yarp::dev::PolyDriver* poly);
+    bool attach(const std::string& deviceKey, yarp::dev::PolyDriver* poly);
 };
 
 HumanDynamicsEstimator::HumanDynamicsEstimator()
@@ -1216,16 +1216,14 @@ void HumanDynamicsEstimator::run()
 
 }
 
-bool HumanDynamicsEstimator::Impl::attach(yarp::dev::PolyDriver* poly)
+bool HumanDynamicsEstimator::Impl::attach(const std::string& deviceKey, yarp::dev::PolyDriver* poly)
 {
     if (!poly) {
         yError() << LogPrefix << "Passed PolyDriver is nullptr";
         return false;
     }
 
-    // Get the device name from the driver
-    const std::string deviceName = poly->getValue("device").asString();
-    yInfo() << LogPrefix << "Attaching device"<<deviceName;
+    yInfo() << LogPrefix << "Attaching device"<<deviceKey;
     
     hde::interfaces::IHumanState* tmpIHumanState = nullptr;
     hde::interfaces::IHumanWrench* tmpIHumanWrench = nullptr;
@@ -1239,7 +1237,7 @@ bool HumanDynamicsEstimator::Impl::attach(yarp::dev::PolyDriver* poly)
                 yarp::os::Time::delay(5);
         }
 
-        yInfo() << LogPrefix << "Device" << deviceName << "attached successfully as IHumanState interfaces";
+        yInfo() << LogPrefix << "Device" << deviceKey << "attached successfully as IHumanState interfaces";
         iHumanState = tmpIHumanState;
     }
 
@@ -1254,13 +1252,13 @@ bool HumanDynamicsEstimator::Impl::attach(yarp::dev::PolyDriver* poly)
             numberOfWrenchSources = tmpIHumanWrench->getNumberOfWrenchSources();
         }
 
-        yInfo() << LogPrefix << "Device" << deviceName << "attached successfully as IHumanWrench";
+        yInfo() << LogPrefix << "Device" << deviceKey << "attached successfully as IHumanWrench";
         iHumanWrench = tmpIHumanWrench;
 
     }
 
     if(!tmpIHumanState && !tmpIHumanWrench){
-        yError() << LogPrefix << "Device" << deviceName << "does not implement any of the attachable interfaces!";
+        yError() << LogPrefix << "Device" << deviceKey << "does not implement any of the attachable interfaces!";
         return false;
     }
 
@@ -1286,7 +1284,7 @@ bool HumanDynamicsEstimator::attachAll(const yarp::dev::PolyDriverList& driverLi
             return false;
         }
 
-        if(!pImpl->attach(driver->poly)){
+        if(!pImpl->attach(driver->key, driver->poly)){
             return false;
         }
     }

--- a/devices/HumanLogger/HumanLogger.cpp
+++ b/devices/HumanLogger/HumanLogger.cpp
@@ -390,6 +390,7 @@ bool HumanLogger::attachAll(const yarp::dev::PolyDriverList& driverList)
 
     for (int i = 0; i < driverList.size(); i++) {
         yarp::dev::PolyDriver* poly = driverList[i]->poly;
+        std::string deviceKey = driverList[i]->key;
 
         if (!poly) {
             yError() << LogPrefix << "Passed PolyDriver is nullptr.";
@@ -397,7 +398,6 @@ bool HumanLogger::attachAll(const yarp::dev::PolyDriverList& driverList)
         }
 
         // Get the device name from the driver
-        const std::string deviceName = poly->getValue("device").asString();
         interfaces::IHumanState* tmpIHumanState = nullptr;
         interfaces::IHumanDynamics* tmpIHumanDynamics = nullptr;
         interfaces::IHumanWrench* tmpIHumanWrench = nullptr;
@@ -445,12 +445,12 @@ bool HumanLogger::attachAll(const yarp::dev::PolyDriverList& driverList)
 
         if(!tmpIHumanState && !tmpIHumanDynamics && !tmpIHumanWrench)
         {
-            yError()<<LogPrefix<<"The device"<<deviceName<<"does not implement any of the attachable interfaces!";
+            yError()<<LogPrefix<<"The device"<<deviceKey<<"does not implement any of the attachable interfaces!";
             return false;
         }
         else
         {
-            yInfo()<<LogPrefix<<"Device"<<deviceName<<"successfully attached";
+            yInfo()<<LogPrefix<<"Device"<<deviceKey<<"successfully attached";
         }
     }
 

--- a/devices/HumanWrenchProvider/HumanWrenchProvider.cpp
+++ b/devices/HumanWrenchProvider/HumanWrenchProvider.cpp
@@ -1264,13 +1264,10 @@ bool HumanWrenchProvider::Impl::attach(yarp::dev::PolyDriver* poly)
         return false;
     }
 
-    // Get the device name from the driver
-    const std::string deviceName = poly->getValue("device").asString();
-
     wearable::IWear* tmpIWear = nullptr;
     hde::interfaces::IHumanState* tmpIHumanState = nullptr;
 
-    yInfo()<<LogPrefix<<"Attaching device"<< deviceName;
+    yInfo()<<LogPrefix<<"Attaching device"<< deviceKey;
 
     // Attach IHumanState
     if (!iHumanState && poly->view(tmpIHumanState)) {
@@ -1284,7 +1281,7 @@ bool HumanWrenchProvider::Impl::attach(yarp::dev::PolyDriver* poly)
         }
 
         iHumanState = tmpIHumanState;
-        yInfo() << LogPrefix << "Device" <<deviceName << "attached successfully as IHumanState interface";
+        yInfo() << LogPrefix << "Device" <<deviceKey << "attached successfully as IHumanState interface";
     }
 
     // Attach IWear interface
@@ -1302,7 +1299,7 @@ bool HumanWrenchProvider::Impl::attach(yarp::dev::PolyDriver* poly)
         }
 
         iWear = tmpIWear;
-        yInfo() << LogPrefix << "Device" <<deviceName << "attached successfully as IWear interface";
+        yInfo() << LogPrefix << "Device" <<deviceKey << "attached successfully as IWear interface";
 
         // Get the ft wearable sensors containing the input measurements
         for (auto& ftSensorSourceData : wrenchSources) {
@@ -1375,7 +1372,7 @@ bool HumanWrenchProvider::Impl::attach(yarp::dev::PolyDriver* poly)
 
     if(!tmpIWear && !tmpIHumanState)
     {
-        yError() << LogPrefix << "Device"<<deviceName<<"does not implement any of the attachable interfaces!";
+        yError() << LogPrefix << "Device"<<deviceKey<<"does not implement any of the attachable interfaces!";
         return false;
     }
     

--- a/devices/HumanWrenchProvider/HumanWrenchProvider.cpp
+++ b/devices/HumanWrenchProvider/HumanWrenchProvider.cpp
@@ -160,7 +160,7 @@ public:
 
     iDynTree::SpatialForceVector computeRCMInBaseUsingMeasurements(iDynTree::KinDynComputations& kinDynComputations);
 
-    bool attach(yarp::dev::PolyDriver* poly);
+    bool attach(const std::string& deviceKey, yarp::dev::PolyDriver* poly);
 };
 
 HumanWrenchProvider::HumanWrenchProvider()
@@ -1257,7 +1257,7 @@ void HumanWrenchProvider::run()
     }
 }
 
-bool HumanWrenchProvider::Impl::attach(yarp::dev::PolyDriver* poly)
+bool HumanWrenchProvider::Impl::attach(const std::string& deviceKey, yarp::dev::PolyDriver* poly)
 {
     if (!poly) {
         yError() << LogPrefix << "Passed PolyDriver is nullptr";
@@ -1398,7 +1398,7 @@ bool HumanWrenchProvider::attachAll(const yarp::dev::PolyDriverList& driverList)
             return false;
         }
 
-        if(!pImpl->attach(driver->poly)){
+        if(!pImpl->attach(driver->key, driver->poly)){
             return false;
         }
     }


### PR DESCRIPTION
Fix https://github.com/robotology/human-dynamics-estimation/issues/381 .

Across multiple devices, `deviceName` is actually used for some print information, but it is not particular useful to print the `device`, as if you have multiple devices (for example, a left and right couple of device) both they will have the same `device` value. Instead, it is more useful to print the key that have been passed to the `attachAll` method, that is the name attribute of the `elem` tag child of the in the attach-related element of the yarprobotinterface xml, see for example https://github.com/robotology/wearables/blob/3d57b0b3dd9dae5293cbd5690f91dec4c473dd43/devices/HapticGlove/conf/HapticGlove.xml#L72 .