### PR TITLE
Stop using macos-12 in GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-2019, macos-12]
+        os: [ubuntu-latest, windows-2019, macos-latest]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Action required due to https://github.com/actions/runner-images/issues/10721, switch to `macos-latest` so we do not need to manually update the macos version manually every time.