### PR TITLE
Deprecate  ROS 1-based software and add HUMANSTATEPROVIDER_ENABLE_ROS1VISUALIZER option to disable compilation of it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 include(GNUInstallDirs)
 include(CTest)
 
+option(HUMANSTATEPROVIDER_ENABLE_ROS1VISUALIZER "Enable the ROS 1-based RViz Human State Visualizer" OFF)
 option(HUMANSTATEPROVIDER_ENABLE_VISUALIZER "Enable the iDyntree-irricht based Human State Visualizer" OFF)
 
 find_package(robometry QUIET)
@@ -129,7 +130,11 @@ add_subdirectory(app)
 add_subdirectory(modules)
 add_subdirectory(servers)
 add_subdirectory(clients)
-add_subdirectory(publishers)
+
+if(HUMANSTATEPROVIDER_ENABLE_ROS1VISUALIZER)
+  add_subdirectory(publishers)
+endif()
+
 add_subdirectory(bindings)
 add_subdirectory(HumanDynamicsEstimationLibrary)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Human Dynamics Estimation (HDE)
 
 
-Human Dynamics Estimation (HDE) is a collection of YARP devices for the online estimation of the kinematics and dynamics of a human subject monitored with a set of wearable sensors and/or interacting with a robot. A ROS-based visualizer allows to visualize in real-time the output of the estimation. The devices can be installed and run in Linux, macOS and Windows.
+Human Dynamics Estimation (HDE) is a collection of YARP devices for the online estimation of the kinematics and dynamics of a human subject monitored with a set of wearable sensors and/or interacting with a robot. The devices can be installed and run in Linux, macOS and Windows.
 
 > !NOTE
 > Since September 2024 (release 4.0.0) the human-dynamics-estimation repo contains the software that used to be part of the https://github.com/robotology/wearables repository.
@@ -43,7 +43,6 @@ For installing the dependencies you can decide to install them individually or t
 - [**IPOPT**](http://wiki.icub.org/wiki/Installing_IPOPT): a software package for large-scale nonlinear optimization.
 
 #### Optional dependencies
-- [**ROS**](http://wiki.ros.org) with [**rviz**](http://wiki.ros.org/rviz) package: an open-source provider of libraries and tools for creating robot applications.
 - [**irrlicht**](http://irrlicht.sourceforge.net/) and [**iDynTree**](https://github.com/robotology/idyntree) compiled with `IDYNTREE_USES_IRRLICHT` enabled: visualizer for floating-base rigid-body systems.
 - [**Robometry**](https://github.com/robotology/robometry) : a telemetry suite for logging data.
 - [**pybind11**](https://github.com/pybind/pybind11): if present, the user can enable `HDE_COMPILE_PYTHON_BINDINGS` to enable the compilation of the python bindings.

--- a/msgs/CMakeLists.txt
+++ b/msgs/CMakeLists.txt
@@ -142,4 +142,7 @@ install(TARGETS XsensSuitControl
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 add_subdirectory(yarp)
-add_subdirectory(ros)
+
+if(HUMANSTATEPROVIDER_ENABLE_ROS1VISUALIZER)
+  add_subdirectory(ros)
+endif()


### PR DESCRIPTION
For now I just added an option instead of removing all the folders as:
* it was easier
* it permits to easily re-enable the support if we realize that we actually need a device or msg somewhere (some of these dependencies are at runtime, so ti is not easy to detect them just by compilation)