### PR TITLE
Add missing include of chrono where std::chrono is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(HumanDynamicsEstimation
         LANGUAGES CXX
-        VERSION 4.2.0)
+        VERSION 4.2.1)
 
 # =====================
 # PROJECT CONFIGURATION

--- a/XSensMVN/test/testCalibrator.cpp
+++ b/XSensMVN/test/testCalibrator.cpp
@@ -6,6 +6,9 @@
 
 #include "xme.h"
 
+#include <chrono>
+#include <thread>
+
 int main(int argc, const char* argv[])
 {
     // Create a licence object

--- a/devices/HapticGlove/src/HapticGlove.cpp
+++ b/devices/HapticGlove/src/HapticGlove.cpp
@@ -13,6 +13,7 @@
 #include <yarp/os/RpcServer.h>
 
 #include <assert.h>
+#include <chrono>
 #include <cmath>
 #include <map>
 #include <mutex>

--- a/devices/HumanStateProvider/IKWorkerPool.cpp
+++ b/devices/HumanStateProvider/IKWorkerPool.cpp
@@ -7,6 +7,7 @@
 
 #include <iDynTree/Core/EigenHelpers.h>
 
+#include <chrono>
 #include <thread>
 
 const std::string IKLogPrefix = "IKWorkerPool :";

--- a/devices/Paexo/src/Paexo.cpp
+++ b/devices/Paexo/src/Paexo.cpp
@@ -12,6 +12,7 @@
 #include <yarp/os/TypedReaderCallback.h>
 
 #include <assert.h>
+#include <chrono>
 #include <mutex>
 #include <stdexcept>
 #include <stdio.h>

--- a/devices/RobotPositionController/RobotPositionController.cpp
+++ b/devices/RobotPositionController/RobotPositionController.cpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <numeric>
+#include <chrono>
 #include <cmath>
 
 #include <thread>


### PR DESCRIPTION
VS 17.13 was released and probably some transitive include changed, creating a lot of errors due to the missing chrono include in code that previously worked fine. This PR fixes the missing include of chrono where std::chrono is used.