### PR TITLE
Refresh CI and general cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-2019, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 This file documents notable changes to this project done before November 2023. For changes after that date, please refer to the release notes of each release at https://github.com/robotology/human-dynamics-estimation/releases.
 
-## [Unreleased]
-
-### Fixed
-- Set the calibrationMeasurementToLink matrix to the initial when `resetAll` rpc command is called (https://github.com/robotology/human-dynamics-estimation/pull/421).
-
 ## [3.0.0] - 2023-11-09
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(HumanDynamicsEstimation
         LANGUAGES CXX
-        VERSION 4.2.1)
+        VERSION 4.2.2)
 
 # =====================
 # PROJECT CONFIGURATION

--- a/ci_env.yml
+++ b/ci_env.yml
@@ -1,17 +1,16 @@
 name: human-dynamics-estimation
 channels:
   - conda-forge
-  - robotology
 dependencies:
   - cmake
-  - compilers
+  - cxx-compiler
   - make
   - ninja
   - pkg-config
   - python
   - pybind11
-  - yarp
-  - icub-main
+  - libyarp
+  - libicub-main
   - idyntree
   - libmatio-cpp
   - librobometry


### PR DESCRIPTION
* Migrate from windows-2019 to windows-latest (see https://github.com/robotology/robotology-superbuild/issues/1858)
* Bump version to 4.2.2
* Remove usage of unnecessary `robotology` channel
* Switch to use library-specific packages for `yarp` and `icub-main` (i.e. use `libyarp` and `libicub-main`)
* Remove spurious changelog entry