### PR TITLE
Fix compatibility with Eigen3 5.0.0

### DIFF
--- a/HumanDynamicsEstimationLibrary/algorithms/src/InverseVelocityKinematics.cpp
+++ b/HumanDynamicsEstimationLibrary/algorithms/src/InverseVelocityKinematics.cpp
@@ -413,7 +413,11 @@ bool InverseVelocityKinematics::impl::solveInverseDifferentialKinematics(
             (iDynTree::toEigen(matrix).transpose() * weightInverse.toDenseMatrix()
                  * iDynTree::toEigen(matrix)
              + iDynTree::toEigen(regularizationMatrix))
+#if EIGEN_VERSION_AT_LEAST(5,0,0)
+                .bdcSvd<Eigen::ComputeFullU | Eigen::ComputeFullV>()
+#else
                 .bdcSvd(Eigen::ComputeFullU | Eigen::ComputeFullV)
+#endif
                 .solve(iDynTree::toEigen(matrix).transpose() * weightInverse.toDenseMatrix()
                        * iDynTree::toEigen(inputVector));
     }

--- a/devices/HumanDynamicsEstimator/CMakeLists.txt
+++ b/devices/HumanDynamicsEstimator/CMakeLists.txt
@@ -16,8 +16,7 @@ yarp_add_plugin(HumanDynamicsEstimator
     HumanDynamicsEstimator.h)
 
 target_include_directories(HumanDynamicsEstimator PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 target_link_libraries(HumanDynamicsEstimator PUBLIC
     IHumanState
@@ -30,6 +29,7 @@ target_link_libraries(HumanDynamicsEstimator PUBLIC
     iDynTree::idyntree-core
     iDynTree::idyntree-model
     iDynTree::idyntree-estimation)
+target_link_libraries(HumanDynamicsEstimator PRIVATE Eigen3::Eigen)
 
 if(MSVC)
   target_compile_options(HumanDynamicsEstimator PRIVATE /bigobj)

--- a/devices/HumanLogger/CMakeLists.txt
+++ b/devices/HumanLogger/CMakeLists.txt
@@ -17,8 +17,7 @@ yarp_add_plugin(HumanLogger
     HumanLogger.h)
 
 target_include_directories(HumanLogger PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 target_link_libraries(HumanLogger PUBLIC
     YARP::YARP_OS
@@ -29,6 +28,9 @@ target_link_libraries(HumanLogger PUBLIC
     IHumanDynamics
     IHumanWrench
     )
+target_link_libraries(HumanLogger PRIVATE Eigen3::Eigen)
+
+
 
 if(MSVC)
   target_compile_options(HumanLogger PRIVATE /bigobj)

--- a/devices/HumanStateProvider/CMakeLists.txt
+++ b/devices/HumanStateProvider/CMakeLists.txt
@@ -19,8 +19,7 @@ yarp_add_plugin(HumanStateProvider
     IKWorkerPool.h)
 
 target_include_directories(HumanStateProvider PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 target_link_libraries(HumanStateProvider PUBLIC
     YARP::YARP_OS
@@ -36,6 +35,9 @@ target_link_libraries(HumanStateProvider PUBLIC
     HumanDynamicsEstimation::utils
     HumanDynamicsEstimation::algorithms
     )
+
+target_link_libraries(HumanStateProvider PRIVATE Eigen3::Eigen)
+
 
 if(MSVC)
   target_compile_options(HumanStateProvider PRIVATE /bigobj)

--- a/devices/HumanWrenchProvider/CMakeLists.txt
+++ b/devices/HumanWrenchProvider/CMakeLists.txt
@@ -18,8 +18,7 @@ yarp_add_plugin(HumanWrenchProvider
     WrenchFrameTransformers.h)
 
 target_include_directories(HumanWrenchProvider PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 target_link_libraries(HumanWrenchProvider PUBLIC
     IHumanState
@@ -33,6 +32,7 @@ target_link_libraries(HumanWrenchProvider PUBLIC
     iDynTree::idyntree-model
     iDynTree::idyntree-estimation
     iDynTree::idyntree-high-level)
+target_link_libraries(HumanWrenchProvider PRIVATE Eigen3::Eigen)
 
 yarp_install(
     TARGETS HumanWrenchProvider


### PR DESCRIPTION
In particular, we change how SVD is invoked to deal with https://gitlab.com/libeigen/eigen/-/merge_requests/826/diffs#10a394f8d6cafac3a0b5c595a09e93071cf661f4, and we switch from using the `EIGEN3_INCLUDE_DIR` variable (removed in Eigen3 5.0.0) to the `Eigen3::Eigen` imported target.




xref: https://github.com/robotology/robotology-superbuild/issues/1902
xref: https://github.com/robotology/robotology-superbuild/issues/1903
xref: https://github.com/conda-forge/eigen-feedstock/pull/47